### PR TITLE
use fastmath option by default

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,6 +4,7 @@ project(WaveFD)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
+set(CMAKE_CXX_FLAGS_RELEASE "-O3 -ffast-math")
 
 option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
 


### PR DESCRIPTION
This doubles the efficiency of the propagators and seems to be worth the possible lack of adherence to IEEE/Iso.

---- Before this change the :
# WaveFD Propagator Throughput

|     | 1 threads | 2 threads | 4 threads | 8 threads | 16 threads | 32 threads | 64 threads|
|------| ------ | ------ | ------ | ------ | ------ | ------ | ------ |
| 2DAcoIsoDenQ_DEO2_FDTD | 319.34 MC/s (1.37 %) | 378.16 MC/s (38.34 %) | 873.29 MC/s (18.37 %) | 601.71 MC/s (37.80 %) | 499.05 MC/s (14.89 %) | 803.18 MC/s (10.64 %) | 683.02 MC/s (17.24 %)|
| 2DAcoVTIDenQ_DEO2_FDTD | 63.47 MC/s (0.43 %) | 108.61 MC/s (3.24 %) | 207.04 MC/s (3.07 %) | 397.39 MC/s (6.09 %) | 202.76 MC/s (39.64 %) | 260.36 MC/s (17.38 %) | 367.93 MC/s (16.31 %)|
| 2DAcoTTIDenQ_DEO2_FDTD | 42.24 MC/s (0.55 %) | 75.41 MC/s (1.65 %) | 150.03 MC/s (1.63 %) | 293.09 MC/s (7.06 %) | 421.82 MC/s (10.09 %) | 474.33 MC/s (10.76 %) | 421.73 MC/s (12.03 %)|
| 3DAcoIsoDenQ_DEO2_FDTD | 218.45 MC/s (0.11 %) | 431.20 MC/s (0.16 %) | 854.44 MC/s (0.25 %) | 1644.15 MC/s (0.18 %) | 2654.94 MC/s (0.13 %) | 2829.66 MC/s (0.22 %) | 2794.84 MC/s (2.65 %)|
| 3DAcoVTIDenQ_DEO2_FDTD | 24.58 MC/s (0.01 %) | 48.47 MC/s (0.10 %) | 96.82 MC/s (0.17 %) | 193.10 MC/s (0.14 %) | 380.49 MC/s (0.04 %) | 691.74 MC/s (0.03 %) | 1022.29 MC/s (2.31 %)|
| 3DAcoTTIDenQ_DEO2_FDTD | 12.88 MC/s (NaN %) | 25.43 MC/s (0.13 %) | 50.56 MC/s (0.19 %) | 101.62 MC/s (0.18 %) | 201.55 MC/s (0.06 %) | 401.07 MC/s (0.02 %) | 673.67 MC/s (1.52 %)|

## Julia versioninfo
```
Julia Version 1.5.0
Commit 96786e22cc (2020-08-01 23:44 UTC)
Platform Info:
  OS: Linux (x86_64-pc-linux-gnu)
      "CentOS Linux release 7.8.2003 (Core)"
  uname: Linux 3.10.0-1062.9.1.el7.x86_64 #1 SMP Fri Dec 6 15:49:49 UTC 2019 x86_64 x86_64
  CPU: AMD EPYC 7502 32-Core Processor: 
                 speed         user         nice          sys         idle          irq
       #1-64  2500 MHz  11744736097 s  2621737487 s  697723818 s  24172664119 s          0 s
       
  Memory: 503.62003326416016 GB (464988.44921875 MB free)
  Uptime: 6.135385e6 sec
  Load Avg:  13.10302734375  11.21142578125  10.0595703125
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-9.0.1 (ORCJIT, znver1)
```

---- After this change:

# WaveFD Propagator Throughput

|     | 1 threads | 2 threads | 4 threads | 8 threads | 16 threads | 32 threads | 64 threads|
|------| ------ | ------ | ------ | ------ | ------ | ------ | ------ |
| 2DAcoIsoDenQ_DEO2_FDTD | 300.25 MC/s (1.12 %) | 522.00 MC/s (1.62 %) | 886.47 MC/s (12.86 %) | 820.30 MC/s (16.44 %) | 591.57 MC/s (16.97 %) | 629.64 MC/s (21.84 %) | 748.38 MC/s (12.16 %)|
| 2DAcoVTIDenQ_DEO2_FDTD | 64.26 MC/s (1.41 %) | 113.07 MC/s (2.97 %) | 217.82 MC/s (3.07 %) | 354.71 MC/s (11.16 %) | 442.15 MC/s (13.84 %) | 439.04 MC/s (12.79 %) | 373.42 MC/s (19.22 %)|
| 2DAcoTTIDenQ_DEO2_FDTD | 36.82 MC/s (1.01 %) | 74.96 MC/s (0.93 %) | 149.19 MC/s (2.92 %) | 287.45 MC/s (6.88 %) | 179.62 MC/s (30.42 %) | 258.29 MC/s (7.87 %) | 375.87 MC/s (14.13 %)|
| 3DAcoIsoDenQ_DEO2_FDTD | 218.89 MC/s (0.08 %) | 431.51 MC/s (0.12 %) | 855.02 MC/s (0.26 %) | 1647.52 MC/s (0.19 %) | 2661.58 MC/s (0.12 %) | 2830.16 MC/s (0.11 %) | 2801.01 MC/s (2.92 %)|
| 3DAcoVTIDenQ_DEO2_FDTD | 24.57 MC/s (0.08 %) | 48.51 MC/s (0.03 %) | 96.77 MC/s (0.18 %) | 193.01 MC/s (0.14 %) | 379.68 MC/s (0.06 %) | 690.96 MC/s (0.06 %) | 1022.89 MC/s (1.64 %)|
| 3DAcoTTIDenQ_DEO2_FDTD | 33.04 MC/s (0.00 %) | 65.15 MC/s (0.47 %) | 129.95 MC/s (0.13 %) | 259.61 MC/s (0.17 %) | 513.95 MC/s (0.07 %) | 988.14 MC/s (0.05 %) | 1276.02 MC/s (4.48 %)|

## Julia versioninfo
```
Julia Version 1.5.0
Commit 96786e22cc (2020-08-01 23:44 UTC)
Platform Info:
  OS: Linux (x86_64-pc-linux-gnu)
      "CentOS Linux release 7.8.2003 (Core)"
  uname: Linux 3.10.0-1062.9.1.el7.x86_64 #1 SMP Fri Dec 6 15:49:49 UTC 2019 x86_64 x86_64
  CPU: AMD EPYC 7502 32-Core Processor: 
                 speed         user         nice          sys         idle          irq
       #1-64  2500 MHz  11743266059 s  2621737487 s  697561352 s  24163312861 s          0 s
       
  Memory: 503.62003326416016 GB (433308.171875 MB free)
  Uptime: 6.133669e6 sec
  Load Avg:  13.20361328125  11.01806640625  9.6552734375
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-9.0.1 (ORCJIT, znver1)
```