### PR TITLE
Dispatch on object rather than type.

### DIFF
--- a/src/prop2DAcoTTIDenQ_DEO2_FDTD.jl
+++ b/src/prop2DAcoTTIDenQ_DEO2_FDTD.jl
@@ -64,13 +64,13 @@ abstract type Prop2DAcoTTIDenQ_DEO2_FDTD_Model end
 
 # v,ϵ,η
 struct Prop2DAcoTTIDenQ_DEO2_FDTD_Model_VEA <: Prop2DAcoTTIDenQ_DEO2_FDTD_Model end
-function forwardBornInjection!(prop::Prop2DAcoTTIDenQ_DEO2_FDTD,::Type{Prop2DAcoTTIDenQ_DEO2_FDTD_Model_VEA},dmodel,wavefield)
+function forwardBornInjection!(prop::Prop2DAcoTTIDenQ_DEO2_FDTD,modeltype::Prop2DAcoTTIDenQ_DEO2_FDTD_Model_VEA,dmodel,wavefield)
     ccall((:Prop2DAcoTTIDenQ_DEO2_FDTD_ForwardBornInjection_VEA, libprop2DAcoTTIDenQ_DEO2_FDTD), Cvoid,
         (Ptr{Cvoid}, Ptr{Cfloat}, Ptr{Cfloat}, Ptr{Cfloat}, Ptr{Cfloat},       Ptr{Cfloat},       Ptr{Cfloat},         Ptr{Cfloat}),
          prop.p,     dmodel["v"], dmodel["ϵ"], dmodel["η"], wavefield["pold"], wavefield["mold"], wavefield["pspace"], wavefield["mspace"])
 end
 
-function adjointBornAccumulation!(prop::Prop2DAcoTTIDenQ_DEO2_FDTD,::Type{Prop2DAcoTTIDenQ_DEO2_FDTD_Model_VEA},dmodel,wavefield)
+function adjointBornAccumulation!(prop::Prop2DAcoTTIDenQ_DEO2_FDTD,modeltype::Prop2DAcoTTIDenQ_DEO2_FDTD_Model_VEA,dmodel,wavefield)
     ccall((:Prop2DAcoTTIDenQ_DEO2_FDTD_AdjointBornAccumulation_VEA, libprop2DAcoTTIDenQ_DEO2_FDTD), Cvoid,
         (Ptr{Cvoid}, Ptr{Cfloat}, Ptr{Cfloat}, Ptr{Cfloat}, Ptr{Cfloat},       Ptr{Cfloat},       Ptr{Cfloat},         Ptr{Cfloat}),
          prop.p,     dmodel["v"], dmodel["ϵ"], dmodel["η"], wavefield["pold"], wavefield["mold"], wavefield["pspace"], wavefield["mspace"])
@@ -78,13 +78,13 @@ end
 
 # v
 struct Prop2DAcoTTIDenQ_DEO2_FDTD_Model_V <: Prop2DAcoTTIDenQ_DEO2_FDTD_Model end
-function forwardBornInjection!(prop::Prop2DAcoTTIDenQ_DEO2_FDTD,::Type{Prop2DAcoTTIDenQ_DEO2_FDTD_Model_V},dmodel,wavefield)
+function forwardBornInjection!(prop::Prop2DAcoTTIDenQ_DEO2_FDTD,modeltype::Prop2DAcoTTIDenQ_DEO2_FDTD_Model_V,dmodel,wavefield)
     ccall((:Prop2DAcoTTIDenQ_DEO2_FDTD_ForwardBornInjection_V, libprop2DAcoTTIDenQ_DEO2_FDTD), Cvoid,
         (Ptr{Cvoid}, Ptr{Cfloat}, Ptr{Cfloat},         Ptr{Cfloat}),
          prop.p,     dmodel["v"], wavefield["pspace"], wavefield["mspace"])
 end
 
-function adjointBornAccumulation!(prop::Prop2DAcoTTIDenQ_DEO2_FDTD,::Type{Prop2DAcoTTIDenQ_DEO2_FDTD_Model_V},dmodel,wavefield)
+function adjointBornAccumulation!(prop::Prop2DAcoTTIDenQ_DEO2_FDTD,modeltype::Prop2DAcoTTIDenQ_DEO2_FDTD_Model_V,dmodel,wavefield)
     ccall((:Prop2DAcoTTIDenQ_DEO2_FDTD_AdjointBornAccumulation_V, libprop2DAcoTTIDenQ_DEO2_FDTD), Cvoid,
         (Ptr{Cvoid}, Ptr{Cfloat}, Ptr{Cfloat},         Ptr{Cfloat}),
          prop.p,     dmodel["v"], wavefield["pspace"], wavefield["mspace"])

--- a/src/prop2DAcoVTIDenQ_DEO2_FDTD.jl
+++ b/src/prop2DAcoVTIDenQ_DEO2_FDTD.jl
@@ -65,13 +65,13 @@ abstract type Prop2DAcoVTIDenQ_DEO2_FDTD_Model end
 
 # v,ϵ and η in model-space
 struct Prop2DAcoVTIDenQ_DEO2_FDTD_Model_VEA <: Prop2DAcoVTIDenQ_DEO2_FDTD_Model end
-function forwardBornInjection!(prop::Prop2DAcoVTIDenQ_DEO2_FDTD,::Type{Prop2DAcoVTIDenQ_DEO2_FDTD_Model_VEA},dmodel,wavefields)
+function forwardBornInjection!(prop::Prop2DAcoVTIDenQ_DEO2_FDTD,modeltype::Prop2DAcoVTIDenQ_DEO2_FDTD_Model_VEA,dmodel,wavefields)
     ccall((:Prop2DAcoVTIDenQ_DEO2_FDTD_ForwardBornInjection_VEA, libprop2DAcoVTIDenQ_DEO2_FDTD), Cvoid,
         (Ptr{Cvoid}, Ptr{Cfloat}, Ptr{Cfloat}, Ptr{Cfloat}, Ptr{Cfloat},        Ptr{Cfloat},        Ptr{Cfloat},          Ptr{Cfloat}),
          prop.p,     dmodel["v"], dmodel["ϵ"], dmodel["η"], wavefields["pold"], wavefields["mold"], wavefields["pspace"], wavefields["mspace"])
 end
 
-function adjointBornAccumulation!(prop::Prop2DAcoVTIDenQ_DEO2_FDTD,::Type{Prop2DAcoVTIDenQ_DEO2_FDTD_Model_VEA},dmodel,wavefields)
+function adjointBornAccumulation!(prop::Prop2DAcoVTIDenQ_DEO2_FDTD,modeltype::Prop2DAcoVTIDenQ_DEO2_FDTD_Model_VEA,dmodel,wavefields)
     ccall((:Prop2DAcoVTIDenQ_DEO2_FDTD_AdjointBornAccumulation_VEA, libprop2DAcoVTIDenQ_DEO2_FDTD), Cvoid,
         (Ptr{Cvoid}, Ptr{Cfloat}, Ptr{Cfloat}, Ptr{Cfloat}, Ptr{Cfloat},        Ptr{Cfloat},        Ptr{Cfloat},          Ptr{Cfloat}),
          prop.p,     dmodel["v"], dmodel["ϵ"], dmodel["η"], wavefields["pold"], wavefields["mold"], wavefields["pspace"], wavefields["mspace"])
@@ -79,13 +79,13 @@ end
 
 # v in model-space
 struct Prop2DAcoVTIDenQ_DEO2_FDTD_Model_V <: Prop2DAcoVTIDenQ_DEO2_FDTD_Model end
-function forwardBornInjection!(prop::Prop2DAcoVTIDenQ_DEO2_FDTD,::Type{Prop2DAcoVTIDenQ_DEO2_FDTD_Model_V},dmodel,wavefields)
+function forwardBornInjection!(prop::Prop2DAcoVTIDenQ_DEO2_FDTD,modeltype::Prop2DAcoVTIDenQ_DEO2_FDTD_Model_V,dmodel,wavefields)
     ccall((:Prop2DAcoVTIDenQ_DEO2_FDTD_ForwardBornInjection_V, libprop2DAcoVTIDenQ_DEO2_FDTD), Cvoid,
         (Ptr{Cvoid}, Ptr{Cfloat}, Ptr{Cfloat},          Ptr{Cfloat}),
          prop.p,     dmodel["v"], wavefields["pspace"], wavefields["mspace"])
 end
 
-function adjointBornAccumulation!(prop::Prop2DAcoVTIDenQ_DEO2_FDTD,::Type{Prop2DAcoVTIDenQ_DEO2_FDTD_Model_V},dmodel,wavefields)
+function adjointBornAccumulation!(prop::Prop2DAcoVTIDenQ_DEO2_FDTD,modeltype::Prop2DAcoVTIDenQ_DEO2_FDTD_Model_V,dmodel,wavefields)
     ccall((:Prop2DAcoVTIDenQ_DEO2_FDTD_AdjointBornAccumulation_V, libprop2DAcoVTIDenQ_DEO2_FDTD), Cvoid,
         (Ptr{Cvoid}, Ptr{Cfloat}, Ptr{Cfloat},          Ptr{Cfloat}),
          prop.p,     dmodel["v"], wavefields["pspace"], wavefields["mspace"])

--- a/src/prop3DAcoTTIDenQ_DEO2_FDTD.jl
+++ b/src/prop3DAcoTTIDenQ_DEO2_FDTD.jl
@@ -61,13 +61,13 @@ abstract type Prop3DAcoTTIDenQ_DEO2_FDTD_Model end
 
 # v,ϵ,η
 struct Prop3DAcoTTIDenQ_DEO2_FDTD_Model_VEA <: Prop3DAcoTTIDenQ_DEO2_FDTD_Model end
-function forwardBornInjection!(prop::Prop3DAcoTTIDenQ_DEO2_FDTD,::Type{Prop3DAcoTTIDenQ_DEO2_FDTD_Model_VEA},dmodel,wavefield)
+function forwardBornInjection!(prop::Prop3DAcoTTIDenQ_DEO2_FDTD,modeltype::Prop3DAcoTTIDenQ_DEO2_FDTD_Model_VEA,dmodel,wavefield)
     ccall((:Prop3DAcoTTIDenQ_DEO2_FDTD_ForwardBornInjection_VEA, libprop3DAcoTTIDenQ_DEO2_FDTD), Cvoid,
         (Ptr{Cvoid}, Ptr{Cfloat}, Ptr{Cfloat}, Ptr{Cfloat}, Ptr{Cfloat},       Ptr{Cfloat},       Ptr{Cfloat},         Ptr{Cfloat}),
          prop.p,     dmodel["v"], dmodel["ϵ"], dmodel["η"], wavefield["pold"], wavefield["mold"], wavefield["pspace"], wavefield["mspace"])
 end
 
-function adjointBornAccumulation!(prop::Prop3DAcoTTIDenQ_DEO2_FDTD,::Type{Prop3DAcoTTIDenQ_DEO2_FDTD_Model_VEA},dmodel,wavefield)
+function adjointBornAccumulation!(prop::Prop3DAcoTTIDenQ_DEO2_FDTD,modeltype::Prop3DAcoTTIDenQ_DEO2_FDTD_Model_VEA,dmodel,wavefield)
     ccall((:Prop3DAcoTTIDenQ_DEO2_FDTD_AdjointBornAccumulation_VEA, libprop3DAcoTTIDenQ_DEO2_FDTD), Cvoid,
         (Ptr{Cvoid}, Ptr{Cfloat}, Ptr{Cfloat}, Ptr{Cfloat}, Ptr{Cfloat},       Ptr{Cfloat},       Ptr{Cfloat},         Ptr{Cfloat}),
          prop.p,     dmodel["v"], dmodel["ϵ"], dmodel["η"], wavefield["pold"], wavefield["mold"], wavefield["pspace"], wavefield["mspace"])
@@ -75,13 +75,13 @@ end
 
 # v
 struct Prop3DAcoTTIDenQ_DEO2_FDTD_Model_V <: Prop3DAcoTTIDenQ_DEO2_FDTD_Model end
-function forwardBornInjection!(prop::Prop3DAcoTTIDenQ_DEO2_FDTD,::Type{Prop3DAcoTTIDenQ_DEO2_FDTD_Model_V},dmodel,wavefield)
+function forwardBornInjection!(prop::Prop3DAcoTTIDenQ_DEO2_FDTD,modeltype::Prop3DAcoTTIDenQ_DEO2_FDTD_Model_V,dmodel,wavefield)
     ccall((:Prop3DAcoTTIDenQ_DEO2_FDTD_ForwardBornInjection_V, libprop3DAcoTTIDenQ_DEO2_FDTD), Cvoid,
         (Ptr{Cvoid}, Ptr{Cfloat}, Ptr{Cfloat},         Ptr{Cfloat}),
          prop.p,     dmodel["v"], wavefield["pspace"], wavefield["mspace"])
 end
 
-function adjointBornAccumulation!(prop::Prop3DAcoTTIDenQ_DEO2_FDTD,::Type{Prop3DAcoTTIDenQ_DEO2_FDTD_Model_V},dmodel,wavefield)
+function adjointBornAccumulation!(prop::Prop3DAcoTTIDenQ_DEO2_FDTD,modeltype::Prop3DAcoTTIDenQ_DEO2_FDTD_Model_V,dmodel,wavefield)
     ccall((:Prop3DAcoTTIDenQ_DEO2_FDTD_AdjointBornAccumulation_V, libprop3DAcoTTIDenQ_DEO2_FDTD), Cvoid,
         (Ptr{Cvoid}, Ptr{Cfloat}, Ptr{Cfloat},         Ptr{Cfloat}),
          prop.p,     dmodel["v"], wavefield["pspace"], wavefield["mspace"])

--- a/src/prop3DAcoVTIDenQ_DEO2_FDTD.jl
+++ b/src/prop3DAcoVTIDenQ_DEO2_FDTD.jl
@@ -62,13 +62,13 @@ abstract type Prop3DAcoVTIDenQ_DEO2_FDTD_Model end
 
 # v,ϵ,η
 struct Prop3DAcoVTIDenQ_DEO2_FDTD_Model_VEA <: Prop3DAcoVTIDenQ_DEO2_FDTD_Model end
-function forwardBornInjection!(prop::Prop3DAcoVTIDenQ_DEO2_FDTD,::Type{Prop3DAcoVTIDenQ_DEO2_FDTD_Model_VEA},dmodel,wavefield)
+function forwardBornInjection!(prop::Prop3DAcoVTIDenQ_DEO2_FDTD,modeltype::Prop3DAcoVTIDenQ_DEO2_FDTD_Model_VEA,dmodel,wavefield)
     ccall((:Prop3DAcoVTIDenQ_DEO2_FDTD_ForwardBornInjection_VEA, libprop3DAcoVTIDenQ_DEO2_FDTD), Cvoid,
         (Ptr{Cvoid},Ptr{Cfloat}, Ptr{Cfloat}, Ptr{Cfloat}, Ptr{Cfloat},       Ptr{Cfloat},       Ptr{Cfloat},         Ptr{Cfloat}),
          prop.p,    dmodel["v"], dmodel["ϵ"], dmodel["η"], wavefield["pold"], wavefield["mold"], wavefield["pspace"], wavefield["mspace"])
 end
 
-function adjointBornAccumulation!(prop::Prop3DAcoVTIDenQ_DEO2_FDTD,::Type{Prop3DAcoVTIDenQ_DEO2_FDTD_Model_VEA},dmodel,wavefield)
+function adjointBornAccumulation!(prop::Prop3DAcoVTIDenQ_DEO2_FDTD,modeltype::Prop3DAcoVTIDenQ_DEO2_FDTD_Model_VEA,dmodel,wavefield)
     ccall((:Prop3DAcoVTIDenQ_DEO2_FDTD_AdjointBornAccumulation_VEA, libprop3DAcoVTIDenQ_DEO2_FDTD), Cvoid,
         (Ptr{Cvoid},Ptr{Cfloat}, Ptr{Cfloat}, Ptr{Cfloat}, Ptr{Cfloat},       Ptr{Cfloat},       Ptr{Cfloat},         Ptr{Cfloat}),
          prop.p,    dmodel["v"], dmodel["ϵ"], dmodel["η"], wavefield["pold"], wavefield["mold"], wavefield["pspace"], wavefield["mspace"])
@@ -76,13 +76,13 @@ end
 
 # v
 struct Prop3DAcoVTIDenQ_DEO2_FDTD_Model_V <: Prop3DAcoVTIDenQ_DEO2_FDTD_Model end
-function forwardBornInjection!(prop::Prop3DAcoVTIDenQ_DEO2_FDTD,::Type{Prop3DAcoVTIDenQ_DEO2_FDTD_Model_V},dmodel,wavefield)
+function forwardBornInjection!(prop::Prop3DAcoVTIDenQ_DEO2_FDTD,modeltype::Prop3DAcoVTIDenQ_DEO2_FDTD_Model_V,dmodel,wavefield)
     ccall((:Prop3DAcoVTIDenQ_DEO2_FDTD_ForwardBornInjection_V, libprop3DAcoVTIDenQ_DEO2_FDTD), Cvoid,
         (Ptr{Cvoid},Ptr{Cfloat}, Ptr{Cfloat},         Ptr{Cfloat}),
          prop.p,    dmodel["v"], wavefield["pspace"], wavefield["mspace"])
 end
 
-function adjointBornAccumulation!(prop::Prop3DAcoVTIDenQ_DEO2_FDTD,::Type{Prop3DAcoVTIDenQ_DEO2_FDTD_Model_V},dmodel,wavefield)
+function adjointBornAccumulation!(prop::Prop3DAcoVTIDenQ_DEO2_FDTD,modeltype::Prop3DAcoVTIDenQ_DEO2_FDTD_Model_V,dmodel,wavefield)
     ccall((:Prop3DAcoVTIDenQ_DEO2_FDTD_AdjointBornAccumulation_V, libprop3DAcoVTIDenQ_DEO2_FDTD), Cvoid,
         (Ptr{Cvoid}, Ptr{Cfloat}, Ptr{Cfloat},         Ptr{Cfloat}),
          prop.p,     dmodel["v"], wavefield["pspace"], wavefield["mspace"])


### PR DESCRIPTION
This seems to help Julia with type inference in JetPackWaveFD.   In particular this is the pattern used to dispatch to the correct imaging condition dependent on the earth properties in the model.

## Current pattern
```julia
struct ModelType end
x = (y=ModelType,)
foo(x) = x.y
@code_warntype foo(x)
```
shows:
```
Variables
  #self#::Core.Compiler.Const(foo, false)
  x::NamedTuple{(:y,),Tuple{DataType}}

Body::DataType
1 ─ %1 = Base.getproperty(x, :y)::DataType
└──      return %1
```
where `DataType` is marked red.  I'm not sure why this is the case since `DataType` is concrete.

## New pattern:
```julia
struct ModelType end
x = (y=ModelType(),)
foo(x) = x.y
@code_warntype foo(x)
```
shows
```
Variables
  #self#::Core.Compiler.Const(foo, false)
  x::Core.Compiler.Const((y = ModelType(),), false)

Body::ModelType
1 ─ %1 = Base.getproperty(x, :y)::Core.Compiler.Const(ModelType(), false)
└──      return %1
```