### PR TITLE
Add wavefield separation via Kz wavenumber filter

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "WaveFD"
 uuid = "44f9e87b-acd6-44e6-b5b0-e1db9a6b2dd4"
-version = "0.2.0"
+version = "0.3.0"
 
 [deps]
 CvxCompress = "3e489a4b-a92a-5e1b-a7bf-ed666eae205e"
@@ -17,7 +17,6 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 WaveFD_jll = "c8b78e2a-5255-5058-b631-96af8a7e9abf"
 
 [compat]
-julia = "1"
 CvxCompress = "1"
 DSP = "0.6"
 DistributedArrays = "0.6"
@@ -25,7 +24,8 @@ FFTW = "1"
 NearestNeighbors = "0.4"
 SpecialFunctions = "0.10"
 StaticArrays = "0.12"
-WaveFD_jll = "0.1"
+WaveFD_jll = "0.2"
+julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -66,6 +66,10 @@ for nthreads in _nthreads
     SUITE["2DAcoIsoDenQ_DEO2_FDTD"]["$nthreads threads"] = @benchmarkable WaveFD.propagateforward!(p) setup=(p=p2diso($nthreads,$(n_2D.z),$(n_2D.x),$(nb_2D.z),$(nb_2D.x))) teardown=(free(p))
 end
 
+SUITE["2DAcoIsoDenQ_DEO2_FDTD"]["imaging condition, standard"] = @benchmarkable WaveFD.adjointBornAccumulation!(p,ic,x,y) setup=(p=p2diso(Sys.CPU_THREADS,$(n_2D.z),$(n_2D.x),$(nb_2D.z),$(nb_2D.x)); ic=WaveFD.ImagingConditionStandard(); x=zeros(Float32,$(n_2D.z),$(n_2D.x)); y=zeros(Float32,$(n_2D.z),$(n_2D.x))) teardown=(free(p))
+SUITE["2DAcoIsoDenQ_DEO2_FDTD"]["imaging condition, wave field separation FWI"] = @benchmarkable WaveFD.adjointBornAccumulation!(p,ic,x,y) setup=(p=p2diso(Sys.CPU_THREADS,$(n_2D.z),$(n_2D.x),$(nb_2D.z),$(nb_2D.x)); ic=WaveFD.ImagingConditionWaveFieldSeparationFWI(); x=zeros(Float32,$(n_2D.z),$(n_2D.x)); y=zeros(Float32,$(n_2D.z),$(n_2D.x))) teardown=(free(p))
+SUITE["2DAcoIsoDenQ_DEO2_FDTD"]["imaging condition, wave field separation RTM"] = @benchmarkable WaveFD.adjointBornAccumulation!(p,ic,x,y) setup=(p=p2diso(Sys.CPU_THREADS,$(n_2D.z),$(n_2D.x),$(nb_2D.z),$(nb_2D.x)); ic=WaveFD.ImagingConditionWaveFieldSeparationRTM(); x=zeros(Float32,$(n_2D.z),$(n_2D.x)); y=zeros(Float32,$(n_2D.z),$(n_2D.x))) teardown=(free(p))
+
 SUITE["2DAcoVTIDenQ_DEO2_FDTD"] = BenchmarkGroup([Dict("ncells"=>n_2D.z*n_2D.x,"nbz"=>nb_2D.z,"nbx"=>nb_2D.x,"nthreads"=>_nthreads)])
 function p2dvti(nthreads,nz,nx,nbz,nbx)
     p = WaveFD.Prop2DAcoVTIDenQ_DEO2_FDTD(freesurface=false, nz=nz, nx=nx, nbz=nbz, nbx=nbx, dz=10.0, dx=10.0, dt=0.001, nthreads=nthreads)
@@ -82,6 +86,16 @@ end
 for nthreads in _nthreads
     SUITE["2DAcoVTIDenQ_DEO2_FDTD"]["$nthreads threads"] = @benchmarkable WaveFD.propagateforward!(p) setup=(p=p2dvti($nthreads,$(n_2D.z),$(n_2D.x),$(nb_2D.z),$(nb_2D.x))) teardown=(free(p))
 end
+
+function fields2dvti(p::WaveFD.Prop2DAcoVTIDenQ_DEO2_FDTD)
+    nz,nx=size(p)
+    δm = Dict("v"=>rand(Float32,nz,nx))
+    fields = Dict("pspace"=>rand(Float32,nz,nx),"mspace"=>rand(Float32,nz,nx))
+    δm,fields
+end
+SUITE["2DAcoVTIDenQ_DEO2_FDTD"]["imaging condition, standard"] = @benchmarkable WaveFD.adjointBornAccumulation!(p,WaveFD.Prop2DAcoVTIDenQ_DEO2_FDTD_Model_V(),ic,δm,fields) setup=(p=p2dvti(Sys.CPU_THREADS,$(n_2D.z),$(n_2D.x),$(nb_2D.z),$(nb_2D.x)); ic=WaveFD.ImagingConditionStandard(); (δm,fields)=fields2dvti(p)) teardown=(free(p))
+SUITE["2DAcoVTIDenQ_DEO2_FDTD"]["imaging condition, wave field separation FWI"] = @benchmarkable WaveFD.adjointBornAccumulation!(p,WaveFD.Prop2DAcoVTIDenQ_DEO2_FDTD_Model_V(),ic,δm,fields) setup=(p=p2dvti(Sys.CPU_THREADS,$(n_2D.z),$(n_2D.x),$(nb_2D.z),$(nb_2D.x)); ic=WaveFD.ImagingConditionWaveFieldSeparationFWI(); (δm,fields)=fields2dvti(p)) teardown=(free(p))
+SUITE["2DAcoVTIDenQ_DEO2_FDTD"]["imaging condition, wave field separation RTM"] = @benchmarkable WaveFD.adjointBornAccumulation!(p,WaveFD.Prop2DAcoVTIDenQ_DEO2_FDTD_Model_V(),ic,δm,fields) setup=(p=p2dvti(Sys.CPU_THREADS,$(n_2D.z),$(n_2D.x),$(nb_2D.z),$(nb_2D.x)); ic=WaveFD.ImagingConditionWaveFieldSeparationRTM(); (δm,fields)=fields2dvti(p)) teardown=(free(p))
 
 SUITE["2DAcoTTIDenQ_DEO2_FDTD"] = BenchmarkGroup([Dict("ncells"=>n_2D.z*n_2D.x,"nbz"=>nb_2D.z,"nbx"=>nb_2D.x,"nthreads"=>_nthreads)])
 function p2dtti(nthreads,nz,nx,nbz,nbx)
@@ -101,6 +115,16 @@ end
 for nthreads in _nthreads
     SUITE["2DAcoTTIDenQ_DEO2_FDTD"]["$nthreads threads"] = @benchmarkable WaveFD.propagateforward!(p) setup=(p=p2dtti($nthreads,$(n_2D.z),$(n_2D.x),$(nb_2D.z),$(nb_2D.x))) teardown=(free(p))
 end
+
+function fields2dtti(p::WaveFD.Prop2DAcoTTIDenQ_DEO2_FDTD)
+    nz,nx = size(p)
+    δm = Dict("v"=>rand(Float32,nz,nx))
+    fields = Dict("pspace"=>rand(Float32,nz,nx),"mspace"=>rand(Float32,nz,nx))
+    δm,fields
+end
+SUITE["2DAcoTTIDenQ_DEO2_FDTD"]["imaging condition, standard"] = @benchmarkable WaveFD.adjointBornAccumulation!(p,WaveFD.Prop2DAcoTTIDenQ_DEO2_FDTD_Model_V(),ic,δm,fields) setup=(p=p2dtti(Sys.CPU_THREADS,$(n_2D.z),$(n_2D.x),$(nb_2D.z),$(nb_2D.x)); ic=WaveFD.ImagingConditionStandard(); (δm,fields)=fields2dtti(p)) teardown=(free(p))
+SUITE["2DAcoTTIDenQ_DEO2_FDTD"]["imaging condition, wave field separation FWI"] = @benchmarkable WaveFD.adjointBornAccumulation!(p,WaveFD.Prop2DAcoTTIDenQ_DEO2_FDTD_Model_V(),ic,δm,fields) setup=(p=p2dtti(Sys.CPU_THREADS,$(n_2D.z),$(n_2D.x),$(nb_2D.z),$(nb_2D.x)); ic=WaveFD.ImagingConditionWaveFieldSeparationFWI(); (δm,fields)=fields2dtti(p)) teardown=(free(p))
+SUITE["2DAcoTTIDenQ_DEO2_FDTD"]["imaging condition, wave field separation RTM"] = @benchmarkable WaveFD.adjointBornAccumulation!(p,WaveFD.Prop2DAcoTTIDenQ_DEO2_FDTD_Model_V(),ic,δm,fields) setup=(p=p2dtti(Sys.CPU_THREADS,$(n_2D.z),$(n_2D.x),$(nb_2D.z),$(nb_2D.x)); ic=WaveFD.ImagingConditionWaveFieldSeparationRTM(); (δm,fields)=fields2dtti(p)) teardown=(free(p))
 
 nz,ny,nx = 501,301,1001
 
@@ -145,6 +169,10 @@ for nthreads in _nthreads
     SUITE["3DAcoIsoDenQ_DEO2_FDTD"]["$nthreads threads"] = @benchmarkable WaveFD.propagateforward!(p) setup=(p=p3diso($nthreads,$(n_3D.z),$(n_3D.y),$(n_3D.x),$(nb_3D.z),$(nb_3D.y),$(nb_3D.x))) teardown=(free(p)) seconds=15
 end
 
+SUITE["3DAcoIsoDenQ_DEO2_FDTD"]["imaging condition, standard"] = @benchmarkable WaveFD.adjointBornAccumulation!(p,ic,x,y) setup=(p=p3diso(Sys.CPU_THREADS,$(n_3D.z),$(n_3D.y),$(n_3D.x),$(nb_3D.z),$(nb_3D.y),$(nb_3D.x)); ic=WaveFD.ImagingConditionStandard(); x=zeros(Float32,$(n_3D.z),$(n_3D.y),$(n_3D.x)); y=zeros(Float32,$(n_3D.z),$(n_3D.y),$(n_3D.x))) teardown=(free(p))
+SUITE["3DAcoIsoDenQ_DEO2_FDTD"]["imaging condition, wave field separation FWI"] = @benchmarkable WaveFD.adjointBornAccumulation!(p,ic,x,y) setup=(p=p3diso(Sys.CPU_THREADS,$(n_3D.z),$(n_3D.y),$(n_3D.x),$(nb_3D.z),$(nb_3D.y),$(nb_3D.x)); ic=WaveFD.ImagingConditionWaveFieldSeparationFWI(); x=zeros(Float32,$(n_3D.z),$(n_3D.y),$(n_3D.x)); y=zeros(Float32,$(n_3D.z),$(n_3D.y),$(n_3D.x))) teardown=(free(p))
+SUITE["3DAcoIsoDenQ_DEO2_FDTD"]["imaging condition, wave field separation RTM"] = @benchmarkable WaveFD.adjointBornAccumulation!(p,ic,x,y) setup=(p=p3diso(Sys.CPU_THREADS,$(n_3D.z),$(n_3D.y),$(n_3D.x),$(nb_3D.z),$(nb_3D.y),$(nb_3D.x)); ic=WaveFD.ImagingConditionWaveFieldSeparationRTM(); x=zeros(Float32,$(n_3D.z),$(n_3D.y),$(n_3D.x)); y=zeros(Float32,$(n_3D.z),$(n_3D.y),$(n_3D.x))) teardown=(free(p))
+
 SUITE["3DAcoVTIDenQ_DEO2_FDTD"] = BenchmarkGroup([Dict("ncells"=>n_3D.z*n_3D.y*n_3D.x,"nbz"=>nb_3D.z,"nby"=>nb_3D.y,"nbx"=>nb_3D.x,"nthreads"=>_nthreads)])
 function p3dvti(nthreads,nz,ny,nx,nbz,nby,nbx)
     p = WaveFD.Prop3DAcoVTIDenQ_DEO2_FDTD(freesurface=false, nz=nz, ny=ny, nx=nx, nbz=nbz, nby=nby, nbx=nbx, dz=10.0, dy=10.0, dx=10.0, dt=0.001, nthreads=nthreads)
@@ -161,6 +189,16 @@ end
 for nthreads in _nthreads
     SUITE["3DAcoVTIDenQ_DEO2_FDTD"]["$nthreads threads"] = @benchmarkable WaveFD.propagateforward!(p) setup=(p=p3dvti($nthreads,$(n_3D.z),$(n_3D.y),$(n_3D.x),$(nb_3D.z),$(nb_3D.y),$(nb_3D.x))) teardown=(free(p)) seconds=15
 end
+
+function fields3dvti(p::WaveFD.Prop3DAcoVTIDenQ_DEO2_FDTD)
+    nz,ny,nx=size(p)
+    δm = Dict("v"=>rand(Float32,nz,ny,nx))
+    fields = Dict("pspace"=>rand(Float32,nz,ny,nx),"mspace"=>rand(Float32,nz,ny,nx))
+    δm,fields
+end
+SUITE["3DAcoVTIDenQ_DEO2_FDTD"]["imaging condition, standard"] = @benchmarkable WaveFD.adjointBornAccumulation!(p,WaveFD.Prop3DAcoVTIDenQ_DEO2_FDTD_Model_V(),ic,δm,fields) setup=(p=p3dvti(Sys.CPU_THREADS,$(n_3D.z),$(n_3D.y),$(n_3D.x),$(nb_3D.z),$(nb_3D.y),$(nb_3D.x)); ic=WaveFD.ImagingConditionStandard(); (δm,fields)=fields3dvti(p)) teardown=(free(p))
+SUITE["3DAcoVTIDenQ_DEO2_FDTD"]["imaging condition, wave field separation FWI"] = @benchmarkable WaveFD.adjointBornAccumulation!(p,WaveFD.Prop3DAcoVTIDenQ_DEO2_FDTD_Model_V(),ic,δm,fields) setup=(p=p3dvti(Sys.CPU_THREADS,$(n_3D.z),$(n_3D.y),$(n_3D.x),$(nb_3D.z),$(nb_3D.y),$(nb_3D.x)); ic=WaveFD.ImagingConditionWaveFieldSeparationFWI(); (δm,fields)=fields3dvti(p)) teardown=(free(p))
+SUITE["3DAcoVTIDenQ_DEO2_FDTD"]["imaging condition, wave field separation RTM"] = @benchmarkable WaveFD.adjointBornAccumulation!(p,WaveFD.Prop3DAcoVTIDenQ_DEO2_FDTD_Model_V(),ic,δm,fields) setup=(p=p3dvti(Sys.CPU_THREADS,$(n_3D.z),$(n_3D.y),$(n_3D.x),$(nb_3D.z),$(nb_3D.y),$(nb_3D.x)); ic=WaveFD.ImagingConditionWaveFieldSeparationRTM(); (δm,fields)=fields3dvti(p)) teardown=(free(p))
 
 SUITE["3DAcoTTIDenQ_DEO2_FDTD"] = BenchmarkGroup([Dict("ncells"=>n_3D.z*n_3D.y*n_3D.x,"nbz"=>nb_3D.z,"nby"=>nb_3D.y,"nbx"=>nb_3D.x,"nthreads"=>_nthreads)])
 function p3dtti(nthreads,nz,ny,nx,nbz,nby,nbx)
@@ -182,6 +220,16 @@ end
 for nthreads in _nthreads
     SUITE["3DAcoTTIDenQ_DEO2_FDTD"]["$nthreads threads"] = @benchmarkable WaveFD.propagateforward!(p) setup=(p=p3dtti($nthreads,$(n_3D.z),$(n_3D.y),$(n_3D.x),$(nb_3D.z),$(nb_3D.y),$(nb_3D.x))) teardown=(free(p)) seconds=15
 end
+
+function fields3dtti(p::WaveFD.Prop3DAcoTTIDenQ_DEO2_FDTD)
+    nz,ny,nx = size(p)
+    δm = Dict("v"=>rand(Float32,nz,ny,nx))
+    fields = Dict("pspace"=>rand(Float32,nz,ny,nx),"mspace"=>rand(Float32,nz,ny,nx))
+    δm,fields
+end
+SUITE["3DAcoTTIDenQ_DEO2_FDTD"]["imaging condition, standard"] = @benchmarkable WaveFD.adjointBornAccumulation!(p,WaveFD.Prop3DAcoTTIDenQ_DEO2_FDTD_Model_V(),ic,δm,fields) setup=(p=p3dtti(Sys.CPU_THREADS,$(n_3D.z),$(n_3D.y),$(n_3D.x),$(nb_3D.z),$(nb_3D.y),$(nb_3D.x)); ic=WaveFD.ImagingConditionStandard(); (δm,fields)=fields3dtti(p)) teardown=(free(p))
+SUITE["3DAcoTTIDenQ_DEO2_FDTD"]["imaging condition, wave field separation FWI"] = @benchmarkable WaveFD.adjointBornAccumulation!(p,WaveFD.Prop3DAcoTTIDenQ_DEO2_FDTD_Model_V(),ic,δm,fields) setup=(p=p3dtti(Sys.CPU_THREADS,$(n_3D.z),$(n_3D.y),$(n_3D.x),$(nb_3D.z),$(nb_3D.y),$(nb_3D.x)); ic=WaveFD.ImagingConditionWaveFieldSeparationFWI(); (δm,fields)=fields3dtti(p)) teardown=(free(p))
+SUITE["3DAcoTTIDenQ_DEO2_FDTD"]["imaging condition, wave field separation RTM"] = @benchmarkable WaveFD.adjointBornAccumulation!(p,WaveFD.Prop3DAcoTTIDenQ_DEO2_FDTD_Model_V(),ic,δm,fields) setup=(p=p3dtti(Sys.CPU_THREADS,$(n_3D.z),$(n_3D.y),$(n_3D.x),$(nb_3D.z),$(nb_3D.y),$(nb_3D.x)); ic=WaveFD.ImagingConditionWaveFieldSeparationRTM(); (δm,fields)=fields3dtti(p)) teardown=(free(p))
 
 include(joinpath(pkgdir(WaveFD), "benchmark", "mcells_per_second.jl"))
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,17 +17,16 @@ add_library(prop3DAcoTTIDenQ_DEO2_FDTD prop3DAcoTTIDenQ_DEO2_FDTD.cc)
 add_library(illumination illumination.c)
 add_library(spacetime spacetime.cc)
 
-find_package(OpenMP)
-if(OpenMP_CXX_FOUND)
-    target_link_libraries(prop2DAcoIsoDenQ_DEO2_FDTD PUBLIC OpenMP::OpenMP_CXX)
-    target_link_libraries(prop2DAcoVTIDenQ_DEO2_FDTD PUBLIC OpenMP::OpenMP_CXX)
-    target_link_libraries(prop2DAcoTTIDenQ_DEO2_FDTD PUBLIC OpenMP::OpenMP_CXX)
-    target_link_libraries(prop3DAcoIsoDenQ_DEO2_FDTD PUBLIC OpenMP::OpenMP_CXX)
-    target_link_libraries(prop3DAcoVTIDenQ_DEO2_FDTD PUBLIC OpenMP::OpenMP_CXX)
-    target_link_libraries(prop3DAcoTTIDenQ_DEO2_FDTD PUBLIC OpenMP::OpenMP_CXX)
-    target_link_libraries(spacetime PUBLIC OpenMP::OpenMP_CXX)
-    target_link_libraries(illumination PUBLIC OpenMP::OpenMP_CXX)
-endif()
+find_package(PkgConfig REQUIRED)
+find_package(OpenMP REQUIRED)
+
+pkg_check_modules(FFTW3F REQUIRED IMPORTED_TARGET fftw3f)
+target_link_libraries(prop2DAcoIsoDenQ_DEO2_FDTD PUBLIC OpenMP::OpenMP_CXX PkgConfig::FFTW3F)
+target_link_libraries(prop2DAcoVTIDenQ_DEO2_FDTD PUBLIC OpenMP::OpenMP_CXX PkgConfig::FFTW3F)
+target_link_libraries(prop2DAcoTTIDenQ_DEO2_FDTD PUBLIC OpenMP::OpenMP_CXX PkgConfig::FFTW3F)
+target_link_libraries(prop3DAcoIsoDenQ_DEO2_FDTD PUBLIC OpenMP::OpenMP_CXX PkgConfig::FFTW3F)
+target_link_libraries(prop3DAcoVTIDenQ_DEO2_FDTD PUBLIC OpenMP::OpenMP_CXX PkgConfig::FFTW3F)
+target_link_libraries(prop3DAcoTTIDenQ_DEO2_FDTD PUBLIC OpenMP::OpenMP_CXX PkgConfig::FFTW3F)
 
 install(TARGETS prop2DAcoIsoDenQ_DEO2_FDTD prop2DAcoVTIDenQ_DEO2_FDTD prop2DAcoTTIDenQ_DEO2_FDTD prop3DAcoIsoDenQ_DEO2_FDTD prop3DAcoVTIDenQ_DEO2_FDTD prop3DAcoTTIDenQ_DEO2_FDTD illumination spacetime
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/src/WaveFD.jl
+++ b/src/WaveFD.jl
@@ -18,6 +18,11 @@ struct LangJulia <: Language end
 show(io::IO, l::LangC) = write(io, "C")
 show(io::IO, l::LangJulia) = write(io, "Julia")
 
+abstract type ImagingCondition end
+struct ImagingConditionStandard <: ImagingCondition end
+struct ImagingConditionWaveFieldSeparationFWI <: ImagingCondition end
+struct ImagingConditionWaveFieldSeparationRTM <: ImagingCondition end
+
 include("stencil.jl")
 include("spacetime.jl")
 include("compressedio.jl")

--- a/src/prop2DAcoIsoDenQ_DEO2_FDTD.cc
+++ b/src/prop2DAcoIsoDenQ_DEO2_FDTD.cc
@@ -14,11 +14,10 @@ void *Prop2DAcoIsoDenQ_DEO2_FDTD_alloc(
         float dt,
         long nbx,
         long nbz) {
-
     bool freeSurface = (fs > 0) ? true : false;
 
     Prop2DAcoIsoDenQ_DEO2_FDTD *p = new Prop2DAcoIsoDenQ_DEO2_FDTD(
-            freeSurface, nthread, nx, nz, nsponge, dx, dz, dt, nbx, nbz);
+        freeSurface, nthread, nx, nz, nsponge, dx, dz, dt, nbx, nbz);
 
     return (void*) p;
 }
@@ -49,14 +48,22 @@ void Prop2DAcoIsoDenQ_DEO2_FDTD_ScaleSpatialDerivatives(void *p) {
     pc->scaleSpatialDerivatives();
 }
 
-void Prop2DAcoIsoDenQ_DEO2_FDTD_ForwardBornInjection(void *p,float *dmodelV, float *wavefieldDP) {
+void Prop2DAcoIsoDenQ_DEO2_FDTD_ForwardBornInjection(
+        void *p, float *dVel, float *wavefieldDP) {
     Prop2DAcoIsoDenQ_DEO2_FDTD *pc = reinterpret_cast<Prop2DAcoIsoDenQ_DEO2_FDTD *>(p);
-    pc->forwardBornInjection(dmodelV, wavefieldDP);
+    pc->forwardBornInjection(dVel, wavefieldDP);
 }
 
-void Prop2DAcoIsoDenQ_DEO2_FDTD_AdjointBornAccumulation(void *p,float *dmodelV, float *wavefieldDP) {
+void Prop2DAcoIsoDenQ_DEO2_FDTD_AdjointBornAccumulation(
+        void *p, float *dVel, float *wavefieldDP) {
     Prop2DAcoIsoDenQ_DEO2_FDTD *pc = reinterpret_cast<Prop2DAcoIsoDenQ_DEO2_FDTD *>(p);
-    pc->adjointBornAccumulation(dmodelV, wavefieldDP);
+    pc->adjointBornAccumulation(dVel, wavefieldDP);
+}
+
+void Prop2DAcoIsoDenQ_DEO2_FDTD_AdjointBornAccumulation_wavefieldsep(
+        void *p, float *dVel, float *wavefieldDP, const long isFWI) {
+    Prop2DAcoIsoDenQ_DEO2_FDTD *pc = reinterpret_cast<Prop2DAcoIsoDenQ_DEO2_FDTD *>(p);
+    pc->adjointBornAccumulation_wavefieldsep(dVel, wavefieldDP, isFWI);
 }
 
 long Prop2DAcoIsoDenQ_DEO2_FDTD_getNx(void *p) {
@@ -97,16 +104,6 @@ float * Prop2DAcoIsoDenQ_DEO2_FDTD_getPCur(void *p) {
 float * Prop2DAcoIsoDenQ_DEO2_FDTD_getPOld(void *p) {
     Prop2DAcoIsoDenQ_DEO2_FDTD *pc = reinterpret_cast<Prop2DAcoIsoDenQ_DEO2_FDTD *>(p);
     return pc->_pOld;
-}
-
-float * Prop2DAcoIsoDenQ_DEO2_FDTD_getTmpPx(void *p) {
-    Prop2DAcoIsoDenQ_DEO2_FDTD *pc = reinterpret_cast<Prop2DAcoIsoDenQ_DEO2_FDTD *>(p);
-    return pc->_tmpPx1;
-}
-
-float * Prop2DAcoIsoDenQ_DEO2_FDTD_getTmpPz(void *p) {
-    Prop2DAcoIsoDenQ_DEO2_FDTD *pc = reinterpret_cast<Prop2DAcoIsoDenQ_DEO2_FDTD *>(p);
-    return pc->_tmpPz1;
 }
 
 }

--- a/src/prop2DAcoTTIDenQ_DEO2_FDTD.cc
+++ b/src/prop2DAcoTTIDenQ_DEO2_FDTD.cc
@@ -48,32 +48,36 @@ void Prop2DAcoTTIDenQ_DEO2_FDTD_ScaleSpatialDerivatives(void *p) {
     pc->scaleSpatialDerivatives();
 }
 
-void Prop2DAcoTTIDenQ_DEO2_FDTD_ForwardBornInjection_V(void *p,
-        float *dmodelV,
-        float *wavefieldDP, float *wavefieldDM) {
+void Prop2DAcoTTIDenQ_DEO2_FDTD_ForwardBornInjection_V(
+        void *p, float *dVel, float *wavefieldDP, float *wavefieldDM) {
 	Prop2DAcoTTIDenQ_DEO2_FDTD *pc = reinterpret_cast<Prop2DAcoTTIDenQ_DEO2_FDTD *>(p);
-	pc->forwardBornInjection_V(dmodelV, wavefieldDP, wavefieldDM);
+	pc->forwardBornInjection_V(dVel, wavefieldDP, wavefieldDM);
 }
 
-void Prop2DAcoTTIDenQ_DEO2_FDTD_ForwardBornInjection_VEA(void *p,
-        float *dmodelV, float *dmodelE, float *dmodelA,
+void Prop2DAcoTTIDenQ_DEO2_FDTD_ForwardBornInjection_VEA(
+        void *p, float *dVel, float *dEps, float *dEta,
         float *wavefieldP, float *wavefieldM, float *wavefieldDP, float *wavefieldDM) {
 	Prop2DAcoTTIDenQ_DEO2_FDTD *pc = reinterpret_cast<Prop2DAcoTTIDenQ_DEO2_FDTD *>(p);
-	pc->forwardBornInjection_VEA(dmodelV, dmodelE, dmodelA, wavefieldP, wavefieldM, wavefieldDP, wavefieldDM);
+	pc->forwardBornInjection_VEA(dVel, dEps, dEta, wavefieldP, wavefieldM, wavefieldDP, wavefieldDM);
 }
 
-void Prop2DAcoTTIDenQ_DEO2_FDTD_AdjointBornAccumulation_V(void *p,
-        float *dmodelV,
-        float *wavefieldDP, float *wavefieldDM) {
+void Prop2DAcoTTIDenQ_DEO2_FDTD_AdjointBornAccumulation_V(
+        void *p, float *dVel, float *wavefieldDP, float *wavefieldDM) {
     Prop2DAcoTTIDenQ_DEO2_FDTD *pc = reinterpret_cast<Prop2DAcoTTIDenQ_DEO2_FDTD *>(p);
-    pc->adjointBornAccumulation_V(dmodelV, wavefieldDP, wavefieldDM);
+    pc->adjointBornAccumulation_V(dVel, wavefieldDP, wavefieldDM);
 }
 
-void Prop2DAcoTTIDenQ_DEO2_FDTD_AdjointBornAccumulation_VEA(void *p,
-        float *dmodelV, float *dmodelE, float *dmodelA,
+void Prop2DAcoTTIDenQ_DEO2_FDTD_AdjointBornAccumulation_wavefieldsep_V(
+        void *p, float *dVel, float *wavefieldDP, float *wavefieldDM, const long isFWI) {
+    Prop2DAcoTTIDenQ_DEO2_FDTD *pc = reinterpret_cast<Prop2DAcoTTIDenQ_DEO2_FDTD *>(p);
+    pc->adjointBornAccumulation_wavefieldsep_V(dVel, wavefieldDP, wavefieldDM, isFWI);
+}
+
+void Prop2DAcoTTIDenQ_DEO2_FDTD_AdjointBornAccumulation_VEA(
+        void *p, float *dVel, float *dEps, float *dEta,
         float *wavefieldP, float *wavefieldM, float *wavefieldDP, float *wavefieldDM) {
     Prop2DAcoTTIDenQ_DEO2_FDTD *pc = reinterpret_cast<Prop2DAcoTTIDenQ_DEO2_FDTD *>(p);
-    pc->adjointBornAccumulation_VEA(dmodelV, dmodelE, dmodelA, wavefieldP, wavefieldM, wavefieldDP, wavefieldDM);
+    pc->adjointBornAccumulation_VEA(dVel, dEps, dEta, wavefieldP, wavefieldM, wavefieldDP, wavefieldDM);
 }
 
 long Prop2DAcoTTIDenQ_DEO2_FDTD_getNx(void *p) {
@@ -154,26 +158,6 @@ float * Prop2DAcoTTIDenQ_DEO2_FDTD_getMCur(void *p) {
 float * Prop2DAcoTTIDenQ_DEO2_FDTD_getMOld(void *p) {
     Prop2DAcoTTIDenQ_DEO2_FDTD *pc = reinterpret_cast<Prop2DAcoTTIDenQ_DEO2_FDTD *>(p);
     return pc->_mOld;
-}
-
-float * Prop2DAcoTTIDenQ_DEO2_FDTD_getTmpPg1(void *p) {
-    Prop2DAcoTTIDenQ_DEO2_FDTD *pc = reinterpret_cast<Prop2DAcoTTIDenQ_DEO2_FDTD *>(p);
-    return pc->_tmpPg1a;
-}
-
-float * Prop2DAcoTTIDenQ_DEO2_FDTD_getTmpPg3(void *p) {
-    Prop2DAcoTTIDenQ_DEO2_FDTD *pc = reinterpret_cast<Prop2DAcoTTIDenQ_DEO2_FDTD *>(p);
-    return pc->_tmpPg3a;
-}
-
-float * Prop2DAcoTTIDenQ_DEO2_FDTD_getTmpMg1(void *p) {
-    Prop2DAcoTTIDenQ_DEO2_FDTD *pc = reinterpret_cast<Prop2DAcoTTIDenQ_DEO2_FDTD *>(p);
-    return pc->_tmpMg1a;
-}
-
-float * Prop2DAcoTTIDenQ_DEO2_FDTD_getTmpMg3(void *p) {
-    Prop2DAcoTTIDenQ_DEO2_FDTD *pc = reinterpret_cast<Prop2DAcoTTIDenQ_DEO2_FDTD *>(p);
-    return pc->_tmpMg3a;
 }
 
 }

--- a/src/prop2DAcoTTIDenQ_DEO2_FDTD.h
+++ b/src/prop2DAcoTTIDenQ_DEO2_FDTD.h
@@ -6,13 +6,15 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <math.h>
+#include <fftw3.h>
+#include <complex>
 
 #define MIN(x,y) ((x)<(y)?(x):(y))
 
 class Prop2DAcoTTIDenQ_DEO2_FDTD {
 
 public:
-const bool _freeSurface;
+    const bool _freeSurface;
     const long _nbx, _nbz, _nthread, _nx, _nz, _nsponge;
     const float _dx, _dz, _dt;
     const float _c8_1, _c8_2, _c8_3, _c8_4, _invDx, _invDz;
@@ -36,10 +38,10 @@ const bool _freeSurface;
     float * __restrict__ _tmpPg3b = NULL;
     float * __restrict__ _tmpMg1b = NULL;
     float * __restrict__ _tmpMg3b = NULL;
-    float * _pCur = NULL;
     float * _pOld = NULL;
-    float * _mCur = NULL;
+    float * _pCur = NULL;
     float * _mOld = NULL;
+    float * _mCur = NULL;
 
     Prop2DAcoTTIDenQ_DEO2_FDTD(
         bool freeSurface,
@@ -51,7 +53,7 @@ const bool _freeSurface;
         float dz,
         float dt,
         const long nbx,
-        const long nbz = 24) :
+        const long nbz) :
             _freeSurface(freeSurface),
             _nthread(nthread),
             _nx(nx),
@@ -278,7 +280,7 @@ __attribute__((target_clones("avx","avx2","avx512f","default")))
             _tmpPg1a, _tmpPg3a, _tmpMg1a, _tmpMg3a, _sinTheta, _cosTheta, _v, _b, _dtOmegaInvQ,
             _pCur, _mCur, _pSpace, _mSpace, _pOld, _mOld, _nbx, _nbz);
 
-        // swap pointers to be consistent with mjolnir kernel
+        // swap pointers
         float *pswap = _pOld;
         _pOld = _pCur;
         _pCur = pswap;
@@ -317,8 +319,6 @@ __attribute__((target_clones("avx","avx2","avx512f","default")))
     /**
     * Add the Born source at the current time
     *
-    * Note: the three components of the model are dVel, dEps, dEta
-    *
     * User must have:
     *   - called the nonlinear forward
     *   - saved 2nd time derivative of pressure at corresponding time index in array dp2
@@ -327,8 +327,7 @@ __attribute__((target_clones("avx","avx2","avx512f","default")))
 #if defined(__FUNCTION_CLONES__)
 __attribute__((target_clones("avx","avx2","avx512f","default")))
 #endif
-    inline void forwardBornInjection_V(float *dVel,
-            float *wavefieldDP, float *wavefieldDM) {
+    inline void forwardBornInjection_V(float *dVel, float *wavefieldDP, float *wavefieldDM) {
 #pragma omp parallel for collapse(2) num_threads(_nthread) schedule(static)
         for (long bx = 0; bx < _nx; bx += _nbx) {
             for (long bz = 0; bz < _nz; bz += _nbz) {
@@ -363,6 +362,7 @@ __attribute__((target_clones("avx","avx2","avx512f","default")))
     inline void forwardBornInjection_VEA(float *dVel, float *dEps, float *dEta,
         float *wavefieldP, float *wavefieldM, float *wavefieldDP, float *wavefieldDM) {
 
+        // Right side spatial derivatives for the Born source
         applyFirstDerivatives2D_TTI_PlusHalf(
             _freeSurface, _nx, _nz, _nthread, _c8_1, _c8_2, _c8_3, _c8_4, _invDx, _invDz,
             wavefieldP, wavefieldP, _sinTheta, _cosTheta, _tmpPg1a, _tmpPg3a, _nbx, _nbz);
@@ -388,10 +388,7 @@ __attribute__((target_clones("avx","avx2","avx512f","default")))
                         const float E  = _eps[k];
                         const float A  = _eta[k];
                         const float B  = _b[k];
-
                         const float F  = _f[k];
-
-                        const float dV = dVel[k];
                         const float dE = dEps[k];
                         const float dA = dEta[k];
 
@@ -427,14 +424,10 @@ __attribute__((target_clones("avx","avx2","avx512f","default")))
 #pragma omp simd
                     for (long kz = bz; kz < kzmax; kz++) {
                         const long k = kx * _nz + kz;
-
                         const float V  = _v[k];
                         const float B  = _b[k];
                         const float dV = dVel[k];
-
-                        // TODO: simplify these next two lines!
                         const float dt2v2OverB = _dt * _dt * V * V / B;
-
                         const float factor = 2 * B * dV / (V * V * V);
 
                         _pCur[k] += dt2v2OverB * (factor * wavefieldDP[k] + _tmpPg1a[k] + _tmpPg3a[k]);
@@ -447,9 +440,7 @@ __attribute__((target_clones("avx","avx2","avx512f","default")))
 
     /**
     * Accumulate the Born image term at the current time
-    *
-    * Note: the three components of the model are [vel,eps,eta]
-    *
+    * 
     * User must have:
     *   - called the nonlinear forward
     *   - saved 2nd time derivative of pressure at corresponding time index in array dp2
@@ -458,8 +449,7 @@ __attribute__((target_clones("avx","avx2","avx512f","default")))
 #if defined(__FUNCTION_CLONES__)
 __attribute__((target_clones("avx","avx2","avx512f","default")))
 #endif
-    inline void adjointBornAccumulation_V(float *dVel,
-            float *wavefieldDP, float *wavefieldDM) {
+    inline void adjointBornAccumulation_V(float *dVel, float *wavefieldDP, float *wavefieldDM) {
 #pragma omp parallel for collapse(2) num_threads(_nthread) schedule(static)
         for (long bx = 0; bx < _nx; bx += _nbx) {
             for (long bz = 0; bz < _nz; bz += _nbz) {
@@ -470,18 +460,146 @@ __attribute__((target_clones("avx","avx2","avx512f","default")))
 #pragma omp simd
                     for (long kz = bz; kz < kzmax; kz++) {
                         const long k = kx * _nz + kz;
-
                         const float V = _v[k];
                         const float B = _b[k];
-
                         const float factor = 2 * B / (V * V * V);
-
                         dVel[k] += factor * (wavefieldDP[k] * _pOld[k] + wavefieldDM[k] * _mOld[k]);
                     }
                 }
             }
         }
     }
+
+    /**
+     * Apply Kz wavenumber filter for up/down wavefield seperation
+     * Faqi, 2011, Geophysics https://library.seg.org/doi/full/10.1190/1.3533914
+     * 
+     * We handle the FWI and RTM imaging conditions with a condition inside the OMP loop
+     * 
+     * Example Kz filtering with 8 samples 
+     * frequency | +0 | +1 | +2 | +3 |  N | -3 | -2 | -1 |
+     * original  |  0 |  1 |  2 |  3 |  4 |  5 |  6 |  7 |
+     * upgoing   |  0 |  X |  X |  X |  4 |  5 |  6 |  7 |
+     * dngoing   |  0 |  1 |  2 |  3 |  4 |  X |  X |  X |
+     */
+#if defined(__FUNCTION_CLONES__)
+__attribute__((target_clones("avx","avx2","avx512f","default")))
+#endif
+     inline void adjointBornAccumulation_wavefieldsep_V(float *dVel, float *wavefieldDP, float *wavefieldDM, const long isFWI) {
+        const long nfft = 2 * _nz;
+        const float scale = 1.0f / (float)(nfft);
+
+        // FWI: adj wavefield is dngoing
+        // RTM: adj wavefield is upgoing
+        const long kfft_adj = (isFWI) ? 0 : nfft / 2;
+
+        std::complex<float> * __restrict__ tmp = new std::complex<float>[nfft];
+
+        fftwf_plan planForward = fftwf_plan_dft_1d(nfft,
+		    reinterpret_cast<fftwf_complex*>(tmp),
+		    reinterpret_cast<fftwf_complex*>(tmp), +1, FFTW_ESTIMATE);
+
+		fftwf_plan planInverse = fftwf_plan_dft_1d(nfft,
+		    reinterpret_cast<fftwf_complex*>(tmp),
+		    reinterpret_cast<fftwf_complex*>(tmp), -1, FFTW_ESTIMATE);
+
+        delete [] tmp;
+
+#pragma omp parallel num_threads(_nthread)
+        {
+            std::complex<float> * __restrict__ tmp_nlf_p = new std::complex<float>[nfft];
+            std::complex<float> * __restrict__ tmp_adj_p = new std::complex<float>[nfft];
+            std::complex<float> * __restrict__ tmp_nlf_m = new std::complex<float>[nfft];
+            std::complex<float> * __restrict__ tmp_adj_m = new std::complex<float>[nfft];
+
+#pragma omp for schedule(static)
+            for (long bx = 0; bx < _nx; bx += _nbx) {
+                const long kxmax = MIN(bx + _nbx, _nx);
+                for (long kx = bx; kx < kxmax; kx++) {
+
+#pragma omp simd
+                    for (long kfft = 0; kfft < nfft; kfft++) {
+                        tmp_nlf_p[kfft] = 0;
+                        tmp_adj_p[kfft] = 0;
+                        tmp_nlf_m[kfft] = 0;
+                        tmp_adj_m[kfft] = 0;
+                    }  
+
+#pragma omp simd
+                    for (long kz = 0; kz < _nz; kz++) {
+                        const long k = kx * _nz + kz;
+                        tmp_nlf_p[kz] = scale * wavefieldDP[k];
+                        tmp_adj_p[kz] = scale * _pOld[k];
+                        tmp_nlf_m[kz] = scale * wavefieldDM[k];
+                        tmp_adj_m[kz] = scale * _mOld[k];
+                    }  
+
+                    fftwf_execute_dft(planForward,
+                        reinterpret_cast<fftwf_complex*>(tmp_nlf_p),
+                        reinterpret_cast<fftwf_complex*>(tmp_nlf_p));
+
+                    fftwf_execute_dft(planForward,
+                        reinterpret_cast<fftwf_complex*>(tmp_adj_p),
+                        reinterpret_cast<fftwf_complex*>(tmp_adj_p));
+
+                    fftwf_execute_dft(planForward,
+                        reinterpret_cast<fftwf_complex*>(tmp_nlf_m),
+                        reinterpret_cast<fftwf_complex*>(tmp_nlf_m));
+
+                    fftwf_execute_dft(planForward,
+                        reinterpret_cast<fftwf_complex*>(tmp_adj_m),
+                        reinterpret_cast<fftwf_complex*>(tmp_adj_m));
+
+                    // upgoing: zero the positive frequencies, excluding Nyquist
+                    // dngoing: zero the negative frequencies, excluding Nyquist
+#pragma omp simd
+                    for (long k = 1; k < nfft / 2; k++) {
+                        tmp_nlf_p[nfft / 2 + k] = 0;
+                        tmp_adj_p[kfft_adj + k] = 0;
+                        tmp_nlf_m[nfft / 2 + k] = 0;
+                        tmp_adj_m[kfft_adj + k] = 0;
+                    }
+
+                    fftwf_execute_dft(planInverse,
+                        reinterpret_cast<fftwf_complex*>(tmp_nlf_p),
+                        reinterpret_cast<fftwf_complex*>(tmp_nlf_p));
+
+                    fftwf_execute_dft(planInverse,
+                        reinterpret_cast<fftwf_complex*>(tmp_adj_p),
+                        reinterpret_cast<fftwf_complex*>(tmp_adj_p));
+
+                    fftwf_execute_dft(planInverse,
+                        reinterpret_cast<fftwf_complex*>(tmp_nlf_m),
+                        reinterpret_cast<fftwf_complex*>(tmp_nlf_m));
+
+                    fftwf_execute_dft(planInverse,
+                        reinterpret_cast<fftwf_complex*>(tmp_adj_m),
+                        reinterpret_cast<fftwf_complex*>(tmp_adj_m));
+
+                    // Faqi eq 10
+                    // Applied to FWI: [Sup * Rdn]
+                    // Applied to RTM: [Sup * Rup]
+#pragma omp simd
+                    for (long kz = 0; kz < _nz; kz++) {
+                        const long k = kx * _nz + kz;
+                        const float V = _v[k];
+                        const float B = _b[k];
+                        const float factor = 2 * B / (V * V * V);
+                        dVel[k] += factor * (real(tmp_nlf_p[kz] * tmp_adj_p[kz]) + real(tmp_nlf_m[kz] * tmp_adj_m[kz]));
+                    }
+
+                } // end loop over kx
+            } // end loop over bx
+
+            delete [] tmp_nlf_p;
+            delete [] tmp_adj_p;
+            delete [] tmp_nlf_m;
+            delete [] tmp_adj_m;
+        } // end parallel region
+
+        fftwf_destroy_plan(planForward);
+        fftwf_destroy_plan(planInverse);
+     }
 
 #if defined(__FUNCTION_CLONES__)
 __attribute__((target_clones("avx","avx2","avx512f","default")))
@@ -528,7 +646,6 @@ __attribute__((target_clones("avx","avx2","avx512f","default")))
 
                         const float factor = 2 * B / (V * V * V);
 
-                        // why does this appear incosistent with the receiver wavefield extraction only involving p?
                         dVel[k] +=
                             factor * wavefieldDP[k] * _pOld[k] +
                             factor * wavefieldDM[k] * _mOld[k];
@@ -583,7 +700,7 @@ __attribute__((target_clones("avx","avx2","avx512f","default")))
         const long nx4 = nx - 4;
         const long nz4 = nz - 4;
 
-        // zero output array
+        // zero output arrays
 #pragma omp parallel for collapse(2) num_threads(nthread) schedule(static)
         for (long bx = 0; bx < nx; bx += BX_2D) {
             for (long bz = 0; bz < nz; bz += BZ_2D) {
@@ -593,10 +710,11 @@ __attribute__((target_clones("avx","avx2","avx512f","default")))
                 for (long kx = bx; kx < kxmax; kx++) {
 #pragma omp simd
                     for (long kz = bz; kz < kzmax; kz++) {
-                        outPG1[kx * nz + kz] = 0;
-                        outPG3[kx * nz + kz] = 0;
-                        outMG1[kx * nz + kz] = 0;
-                        outMG3[kx * nz + kz] = 0;
+                        long k = kx * nz + kz;
+                        outPG1[k] = 0;
+                        outPG3[k] = 0;
+                        outMG1[k] = 0;
+                        outMG3[k] = 0;
                     }
                 }
             }

--- a/src/prop2DAcoVTIDenQ_DEO2_FDTD.cc
+++ b/src/prop2DAcoVTIDenQ_DEO2_FDTD.cc
@@ -17,7 +17,7 @@ void *Prop2DAcoVTIDenQ_DEO2_FDTD_alloc(
     bool freeSurface = (fs > 0) ? true : false;
 
     Prop2DAcoVTIDenQ_DEO2_FDTD *p = new Prop2DAcoVTIDenQ_DEO2_FDTD(
-            freeSurface, nthread, nx, nz, nsponge, dx, dz, dt, nbx, nbz);
+        freeSurface, nthread, nx, nz, nsponge, dx, dz, dt, nbx, nbz);
 
     return (void*) p;
 }
@@ -38,47 +38,51 @@ void Prop2DAcoVTIDenQ_DEO2_FDTD_SetupDtOmegaInvQ(void *p, float freqQ, float qMi
     setupDtOmegaInvQ_2D(fs, nx, nz, nsponge, nthread, dt, freqQ, qMin, qInterior, pc->_dtOmegaInvQ);
 }
 
-void Prop2DAcoVTIDenQ_DEO2_FDTD_TimeStep(void *p) {
-    Prop2DAcoVTIDenQ_DEO2_FDTD *pc = reinterpret_cast<Prop2DAcoVTIDenQ_DEO2_FDTD *>(p);
-    pc->timeStep();
-}
-
 void Prop2DAcoVTIDenQ_DEO2_FDTD_TimeStepLinear(void *p) {
     Prop2DAcoVTIDenQ_DEO2_FDTD *pc = reinterpret_cast<Prop2DAcoVTIDenQ_DEO2_FDTD *>(p);
     pc->timeStepLinear();
 }
 
-void Prop2DAcoVTIDenQ_DEO2_FDTD_ForwardBornInjection_VEA(
-        void *p, float *dV, float *dE, float *dA,
-        float *wavefieldP, float *wavefieldM, float *wavefieldDP, float *wavefieldDM) {
+void Prop2DAcoVTIDenQ_DEO2_FDTD_TimeStep(void *p) {
     Prop2DAcoVTIDenQ_DEO2_FDTD *pc = reinterpret_cast<Prop2DAcoVTIDenQ_DEO2_FDTD *>(p);
-    pc->forwardBornInjection_VEA(dV, dE, dA, wavefieldP, wavefieldM, wavefieldDP, wavefieldDM);
-}
-
-void Prop2DAcoVTIDenQ_DEO2_FDTD_AdjointBornAccumulation_VEA(
-        void *p, float *dV, float *dE, float *dA,
-        float *wavefieldP, float *wavefieldM, float *wavefieldDP, float *wavefieldDM) {
-    Prop2DAcoVTIDenQ_DEO2_FDTD *pc = reinterpret_cast<Prop2DAcoVTIDenQ_DEO2_FDTD *>(p);
-    pc->adjointBornAccumulation_VEA(dV, dE, dA, wavefieldP, wavefieldM, wavefieldDP, wavefieldDM);
-}
-
-void Prop2DAcoVTIDenQ_DEO2_FDTD_ForwardBornInjection_V(
-        void *p, float *dV,
-        float *wavefieldDP, float *wavefieldDM) {
-    Prop2DAcoVTIDenQ_DEO2_FDTD *pc = reinterpret_cast<Prop2DAcoVTIDenQ_DEO2_FDTD *>(p);
-    pc->forwardBornInjection_V(dV, wavefieldDP, wavefieldDM);
-}
-
-void Prop2DAcoVTIDenQ_DEO2_FDTD_AdjointBornAccumulation_V(
-        void *p, float *dV,
-        float *wavefieldDP, float *wavefieldDM) {
-    Prop2DAcoVTIDenQ_DEO2_FDTD *pc = reinterpret_cast<Prop2DAcoVTIDenQ_DEO2_FDTD *>(p);
-    pc->adjointBornAccumulation_V(dV, wavefieldDP, wavefieldDM);
+    pc->timeStep();
 }
 
 void Prop2DAcoVTIDenQ_DEO2_FDTD_ScaleSpatialDerivatives(void *p) {
     Prop2DAcoVTIDenQ_DEO2_FDTD *pc = reinterpret_cast<Prop2DAcoVTIDenQ_DEO2_FDTD *>(p);
     pc->scaleSpatialDerivatives();
+}
+
+void Prop2DAcoVTIDenQ_DEO2_FDTD_ForwardBornInjection_V(
+        void *p, float *dVel, float *wavefieldDP, float *wavefieldDM) {
+    Prop2DAcoVTIDenQ_DEO2_FDTD *pc = reinterpret_cast<Prop2DAcoVTIDenQ_DEO2_FDTD *>(p);
+    pc->forwardBornInjection_V(dVel, wavefieldDP, wavefieldDM);
+}
+
+void Prop2DAcoVTIDenQ_DEO2_FDTD_ForwardBornInjection_VEA(
+        void *p, float *dVel, float *dEps, float *dEta,
+        float *wavefieldP, float *wavefieldM, float *wavefieldDP, float *wavefieldDM) {
+    Prop2DAcoVTIDenQ_DEO2_FDTD *pc = reinterpret_cast<Prop2DAcoVTIDenQ_DEO2_FDTD *>(p);
+    pc->forwardBornInjection_VEA(dVel, dEps, dEta, wavefieldP, wavefieldM, wavefieldDP, wavefieldDM);
+}
+
+void Prop2DAcoVTIDenQ_DEO2_FDTD_AdjointBornAccumulation_V(
+        void *p, float *dVel, float *wavefieldDP, float *wavefieldDM) {
+    Prop2DAcoVTIDenQ_DEO2_FDTD *pc = reinterpret_cast<Prop2DAcoVTIDenQ_DEO2_FDTD *>(p);
+    pc->adjointBornAccumulation_V(dVel, wavefieldDP, wavefieldDM);
+}
+
+void Prop2DAcoVTIDenQ_DEO2_FDTD_AdjointBornAccumulation_wavefieldsep_V(
+        void *p, float *dVel, float *wavefieldDP, float *wavefieldDM, const long isFWI) {
+    Prop2DAcoVTIDenQ_DEO2_FDTD *pc = reinterpret_cast<Prop2DAcoVTIDenQ_DEO2_FDTD *>(p);
+    pc->adjointBornAccumulation_wavefieldsep_V(dVel, wavefieldDP, wavefieldDM, isFWI);
+}
+
+void Prop2DAcoVTIDenQ_DEO2_FDTD_AdjointBornAccumulation_VEA(
+        void *p, float *dVel, float *dEps, float *dEta,
+        float *wavefieldP, float *wavefieldM, float *wavefieldDP, float *wavefieldDM) {
+    Prop2DAcoVTIDenQ_DEO2_FDTD *pc = reinterpret_cast<Prop2DAcoVTIDenQ_DEO2_FDTD *>(p);
+    pc->adjointBornAccumulation_VEA(dVel, dEps, dEta, wavefieldP, wavefieldM, wavefieldDP, wavefieldDM);
 }
 
 long Prop2DAcoVTIDenQ_DEO2_FDTD_getNx(void *p) {
@@ -149,26 +153,6 @@ float * Prop2DAcoVTIDenQ_DEO2_FDTD_getMCur(void *p) {
 float * Prop2DAcoVTIDenQ_DEO2_FDTD_getMOld(void *p) {
     Prop2DAcoVTIDenQ_DEO2_FDTD *pc = reinterpret_cast<Prop2DAcoVTIDenQ_DEO2_FDTD *>(p);
     return pc->_mOld;
-}
-
-float * Prop2DAcoVTIDenQ_DEO2_FDTD_getTmpPx1(void *p) {
-    Prop2DAcoVTIDenQ_DEO2_FDTD *pc = reinterpret_cast<Prop2DAcoVTIDenQ_DEO2_FDTD *>(p);
-    return pc->_tmpPx1;
-}
-
-float * Prop2DAcoVTIDenQ_DEO2_FDTD_getTmpPz1(void *p) {
-    Prop2DAcoVTIDenQ_DEO2_FDTD *pc = reinterpret_cast<Prop2DAcoVTIDenQ_DEO2_FDTD *>(p);
-    return pc->_tmpPz1;
-}
-
-float * Prop2DAcoVTIDenQ_DEO2_FDTD_getTmpMx1(void *p) {
-    Prop2DAcoVTIDenQ_DEO2_FDTD *pc = reinterpret_cast<Prop2DAcoVTIDenQ_DEO2_FDTD *>(p);
-    return pc->_tmpMx1;
-}
-
-float * Prop2DAcoVTIDenQ_DEO2_FDTD_getTmpMz1(void *p) {
-    Prop2DAcoVTIDenQ_DEO2_FDTD *pc = reinterpret_cast<Prop2DAcoVTIDenQ_DEO2_FDTD *>(p);
-    return pc->_tmpMz1;
 }
 
 }

--- a/src/prop3DAcoIsoDenQ_DEO2_FDTD.cc
+++ b/src/prop3DAcoIsoDenQ_DEO2_FDTD.cc
@@ -17,11 +17,10 @@ void *Prop3DAcoIsoDenQ_DEO2_FDTD_alloc(
         long nbx,
         long nby,
         long nbz) {
-
     bool freeSurface = (fs > 0) ? true : false;
 
     Prop3DAcoIsoDenQ_DEO2_FDTD *p = new Prop3DAcoIsoDenQ_DEO2_FDTD(
-            freeSurface, nthread, nx, ny, nz, nsponge, dx, dy, dz, dt, nbx, nby, nbz);
+        freeSurface, nthread, nx, ny, nz, nsponge, dx, dy, dz, dt, nbx, nby, nbz);
 
     return (void*) p;
 }
@@ -53,14 +52,22 @@ void Prop3DAcoIsoDenQ_DEO2_FDTD_ScaleSpatialDerivatives(void *p) {
     pc->scaleSpatialDerivatives();
 }
 
-void Prop3DAcoIsoDenQ_DEO2_FDTD_ForwardBornInjection(void *p, float *dmodel, float *wavefieldDP) {
+void Prop3DAcoIsoDenQ_DEO2_FDTD_ForwardBornInjection(
+        void *p, float *dVel, float *wavefieldDP) {
     Prop3DAcoIsoDenQ_DEO2_FDTD *pc = reinterpret_cast<Prop3DAcoIsoDenQ_DEO2_FDTD *>(p);
-    pc->forwardBornInjection(dmodel, wavefieldDP);
+    pc->forwardBornInjection(dVel, wavefieldDP);
 }
 
-void Prop3DAcoIsoDenQ_DEO2_FDTD_AdjointBornAccumulation(void *p, float *dmodel, float *wavefieldDP) {
+void Prop3DAcoIsoDenQ_DEO2_FDTD_AdjointBornAccumulation(
+        void *p, float *dVel, float *wavefieldDP) {
     Prop3DAcoIsoDenQ_DEO2_FDTD *pc = reinterpret_cast<Prop3DAcoIsoDenQ_DEO2_FDTD *>(p);
-    pc->adjointBornAccumulation(dmodel, wavefieldDP);
+    pc->adjointBornAccumulation(dVel, wavefieldDP);
+}
+
+void Prop3DAcoIsoDenQ_DEO2_FDTD_AdjointBornAccumulation_wavefieldsep(
+        void *p, float *dVel, float *wavefieldDP, const long isFWI) {
+    Prop3DAcoIsoDenQ_DEO2_FDTD *pc = reinterpret_cast<Prop3DAcoIsoDenQ_DEO2_FDTD *>(p);
+    pc->adjointBornAccumulation_wavefieldsep(dVel, wavefieldDP, isFWI);
 }
 
 long Prop3DAcoIsoDenQ_DEO2_FDTD_getNx(void *p) {
@@ -106,16 +113,6 @@ float * Prop3DAcoIsoDenQ_DEO2_FDTD_getPCur(void *p) {
 float * Prop3DAcoIsoDenQ_DEO2_FDTD_getPOld(void *p) {
     Prop3DAcoIsoDenQ_DEO2_FDTD *pc = reinterpret_cast<Prop3DAcoIsoDenQ_DEO2_FDTD *>(p);
     return pc->_pOld;
-}
-
-float * Prop3DAcoIsoDenQ_DEO2_FDTD_getTmpPx(void *p) {
-    Prop3DAcoIsoDenQ_DEO2_FDTD *pc = reinterpret_cast<Prop3DAcoIsoDenQ_DEO2_FDTD *>(p);
-    return pc->_tmpPx1;
-}
-
-float * Prop3DAcoIsoDenQ_DEO2_FDTD_getTmpPz(void *p) {
-    Prop3DAcoIsoDenQ_DEO2_FDTD *pc = reinterpret_cast<Prop3DAcoIsoDenQ_DEO2_FDTD *>(p);
-    return pc->_tmpPz1;
 }
 
 }

--- a/src/prop3DAcoIsoDenQ_DEO2_FDTD.h
+++ b/src/prop3DAcoIsoDenQ_DEO2_FDTD.h
@@ -6,6 +6,8 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <math.h>
+#include <fftw3.h>
+#include <complex>
 
 #define MIN(x,y) ((x)<(y)?(x):(y))
 
@@ -277,7 +279,7 @@ __attribute__((target_clones("avx","avx2","avx512f","default")))
 #if defined(__FUNCTION_CLONES__)
 __attribute__((target_clones("avx","avx2","avx512f","default")))
 #endif
-    inline void forwardBornInjection(float *dmodel, float *wavefieldDP) {
+    inline void forwardBornInjection(float *dVel, float *wavefieldDP) {
 #pragma omp parallel for collapse(3) num_threads(_nthread) schedule(static)
         for (long bx = 0; bx < _nx; bx += _nbx) {
             for (long by = 0; by < _ny; by += _nby) {
@@ -292,7 +294,7 @@ __attribute__((target_clones("avx","avx2","avx512f","default")))
                             for (long kz = bz; kz < kzmax; kz++) {
                                 const long k = kx * _ny * _nz + ky * _nz + kz;
                                 const float V  = _v[k];
-                                const float dV = dmodel[k];
+                                const float dV = dVel[k];
                                 _pCur[k] += (2 * pow(_dt, 2.0f) * dV * wavefieldDP[k]) / V;
                             }
                         }
@@ -313,7 +315,7 @@ __attribute__((target_clones("avx","avx2","avx512f","default")))
 #if defined(__FUNCTION_CLONES__)
 __attribute__((target_clones("avx","avx2","avx512f","default")))
 #endif
-    inline void adjointBornAccumulation(float *dmodel, float *wavefieldDP) {
+    inline void adjointBornAccumulation(float *dVel, float *wavefieldDP) {
 #pragma omp parallel for collapse(3) num_threads(_nthread) schedule(static)
         for (long bx = 0; bx < _nx; bx += _nbx) {
             for (long by = 0; by < _ny; by += _nby) {
@@ -329,13 +331,119 @@ __attribute__((target_clones("avx","avx2","avx512f","default")))
                                 const long k = kx * _ny * _nz + ky * _nz + kz;
                                 const float V = _v[k];
                                 const float B = _b[k];
-                                dmodel[k] += (2 * B * wavefieldDP[k] * _pOld[k]) / pow(V, 3.0f);
+                                dVel[k] += (2 * B * wavefieldDP[k] * _pOld[k]) / pow(V, 3.0f);
                             }
                         }
                     }
                 }
             }
         }
+    }
+
+    /**
+     * Apply Kz wavenumber filter for up/down wavefield seperation
+     * Faqi, 2011, Geophysics https://library.seg.org/doi/full/10.1190/1.3533914
+     * 
+     * We handle the FWI and RTM imaging conditions with a condition inside the OMP loop
+     * 
+     * Example Kz filtering with 8 samples 
+     * frequency | +0 | +1 | +2 | +3 |  N | -3 | -2 | -1 |
+     * original  |  0 |  1 |  2 |  3 |  4 |  5 |  6 |  7 |
+     * upgoing   |  0 |  X |  X |  X |  4 |  5 |  6 |  7 |
+     * dngoing   |  0 |  1 |  2 |  3 |  4 |  X |  X |  X |
+     */
+#if defined(__FUNCTION_CLONES__)
+__attribute__((target_clones("avx","avx2","avx512f","default")))
+#endif
+    inline void adjointBornAccumulation_wavefieldsep(float *dVel, float *wavefieldDP, const long isFWI) {
+        const long nfft = 2 * _nz;
+        const float scale = 1.0f / (float)(nfft);
+
+        // FWI: adj wavefield is dngoing
+        // RTM: adj wavefield is upgoing
+        const long kfft_adj = (isFWI) ? 0 : nfft / 2;
+
+        std::complex<float> * __restrict__ tmp = new std::complex<float>[nfft];
+
+        fftwf_plan planForward = fftwf_plan_dft_1d(nfft,
+		    reinterpret_cast<fftwf_complex*>(tmp),
+		    reinterpret_cast<fftwf_complex*>(tmp), +1, FFTW_ESTIMATE);
+
+		fftwf_plan planInverse = fftwf_plan_dft_1d(nfft,
+		    reinterpret_cast<fftwf_complex*>(tmp),
+		    reinterpret_cast<fftwf_complex*>(tmp), -1, FFTW_ESTIMATE);
+
+        delete [] tmp;
+
+#pragma omp parallel num_threads(_nthread)
+        {
+            std::complex<float> * __restrict__ tmp_nlf = new std::complex<float>[nfft];
+            std::complex<float> * __restrict__ tmp_adj = new std::complex<float>[nfft];
+
+#pragma omp for  collapse(2) schedule(static)
+            for (long bx = 0; bx < _nx; bx += _nbx) {
+                for (long by = 0; by < _ny; by += _nby) {
+                    const long kxmax = MIN(bx + _nbx, _nx);
+                    const long kymax = MIN(by + _nby, _ny);
+
+                    for (long kx = bx; kx < kxmax; kx++) {
+                        for (long ky = by; ky < kymax; ky++) {
+
+#pragma omp simd
+                            for (long kfft = 0; kfft < nfft; kfft++) {
+                                tmp_nlf[kfft] = 0;
+                                tmp_adj[kfft] = 0;
+                            }  
+
+#pragma omp simd
+                            for (long kz = 0; kz < _nz; kz++) {
+                                const long k = kx * _ny * _nz + ky * _nz + kz;
+                                tmp_nlf[kz] = scale * wavefieldDP[k];
+                                tmp_adj[kz] = scale * _pOld[k];
+                            }  
+
+                            fftwf_execute_dft(planForward,
+                                reinterpret_cast<fftwf_complex*>(tmp_nlf),
+                                reinterpret_cast<fftwf_complex*>(tmp_nlf));
+
+                            fftwf_execute_dft(planForward,
+                                reinterpret_cast<fftwf_complex*>(tmp_adj),
+                                reinterpret_cast<fftwf_complex*>(tmp_adj));
+
+                            // upgoing: zero the positive frequencies, excluding Nyquist
+                            // dngoing: zero the negative frequencies, excluding Nyquist
+#pragma omp simd
+                            for (long k = 1; k < nfft / 2; k++) {
+                                tmp_nlf[nfft / 2 + k] = 0;
+                                tmp_adj[kfft_adj + k] = 0;
+                            }
+
+                            fftwf_execute_dft(planInverse,
+                                reinterpret_cast<fftwf_complex*>(tmp_nlf),
+                                reinterpret_cast<fftwf_complex*>(tmp_nlf));
+
+                            fftwf_execute_dft(planInverse,
+                                reinterpret_cast<fftwf_complex*>(tmp_adj),
+                                reinterpret_cast<fftwf_complex*>(tmp_adj));
+
+                            // Faqi eq 10
+                            // Applied to FWI: [Sup * Rdn]
+                            // Applied to RTM: [Sup * Rup]
+                            for (long kz = 0; kz < _nz; kz++) {
+                                const long k = kx * _ny * _nz + ky * _nz + kz;
+                                const float V = _v[k];
+                                const float B = _b[k];
+                                const float factor = 2 * B / (V * V * V);
+                                dVel[k] += factor * real(tmp_nlf[kz] * tmp_adj[kz]);
+                            }
+                        } // end loop over ky
+                    } // end loop over kx
+                } // end loop over by
+            } // end loop over bx
+            
+            delete [] tmp_nlf;
+            delete [] tmp_adj;
+        } // end parallel region
     }
 
     template<class Type>

--- a/src/prop3DAcoTTIDenQ_DEO2_FDTD.cc
+++ b/src/prop3DAcoTTIDenQ_DEO2_FDTD.cc
@@ -17,11 +17,10 @@ void *Prop3DAcoTTIDenQ_DEO2_FDTD_alloc(
         long nbx,
         long nby,
         long nbz) {
-
     bool freeSurface = (fs > 0) ? true : false;
 
     Prop3DAcoTTIDenQ_DEO2_FDTD *p = new Prop3DAcoTTIDenQ_DEO2_FDTD(
-            freeSurface, nthread, nx, ny, nz, nsponge, dx, dy, dz, dt, nbx, nby, nbz);
+        freeSurface, nthread, nx, ny, nz, nsponge, dx, dy, dz, dt, nbx, nby, nbz);
 
     return (void*) p;
 }
@@ -53,32 +52,36 @@ void Prop3DAcoTTIDenQ_DEO2_FDTD_ScaleSpatialDerivatives(void *p) {
     pc->scaleSpatialDerivatives();
 }
 
-void Prop3DAcoTTIDenQ_DEO2_FDTD_ForwardBornInjection_V(void *p,
-        float *dmodelV,
-        float* wavefieldDP, float* wavefieldDM) {
+void Prop3DAcoTTIDenQ_DEO2_FDTD_ForwardBornInjection_V(
+        void *p, float *dVel, float *wavefieldDP, float *wavefieldDM) {
     Prop3DAcoTTIDenQ_DEO2_FDTD *pc = reinterpret_cast<Prop3DAcoTTIDenQ_DEO2_FDTD *>(p);
-    pc->forwardBornInjection_V(dmodelV, wavefieldDP, wavefieldDM);
+    pc->forwardBornInjection_V(dVel, wavefieldDP, wavefieldDM);
 }
 
-void Prop3DAcoTTIDenQ_DEO2_FDTD_ForwardBornInjection_VEA(void *p,
-        float *dmodelV, float *dmodelE, float *dmodelA,
-        float *wavefieldP, float *wavefieldM, float* wavefieldDP, float* wavefieldDM) {
-    Prop3DAcoTTIDenQ_DEO2_FDTD *pc = reinterpret_cast<Prop3DAcoTTIDenQ_DEO2_FDTD *>(p);
-    pc->forwardBornInjection_VEA(dmodelV, dmodelE, dmodelA, wavefieldP, wavefieldM, wavefieldDP, wavefieldDM);
-}
-
-void Prop3DAcoTTIDenQ_DEO2_FDTD_AdjointBornAccumulation_V(void *p,
-        float *dmodelV,
-        float *wavefieldDP, float *wavefieldDM) {
-    Prop3DAcoTTIDenQ_DEO2_FDTD *pc = reinterpret_cast<Prop3DAcoTTIDenQ_DEO2_FDTD *>(p);
-    pc->adjointBornAccumulation_V(dmodelV, wavefieldDP, wavefieldDM);
-}
-
-void Prop3DAcoTTIDenQ_DEO2_FDTD_AdjointBornAccumulation_VEA(void *p,
-        float *dmodelV, float *dmodelE, float *dmodelA,
+void Prop3DAcoTTIDenQ_DEO2_FDTD_ForwardBornInjection_VEA(
+        void *p, float *dVel, float *dEps, float *dEta,
         float *wavefieldP, float *wavefieldM, float *wavefieldDP, float *wavefieldDM) {
     Prop3DAcoTTIDenQ_DEO2_FDTD *pc = reinterpret_cast<Prop3DAcoTTIDenQ_DEO2_FDTD *>(p);
-    pc->adjointBornAccumulation_VEA(dmodelV, dmodelE, dmodelA, wavefieldP, wavefieldM, wavefieldDP, wavefieldDM);
+    pc->forwardBornInjection_VEA(dVel, dEps, dEta, wavefieldP, wavefieldM, wavefieldDP, wavefieldDM);
+}
+
+void Prop3DAcoTTIDenQ_DEO2_FDTD_AdjointBornAccumulation_V(
+        void *p, float *dVel, float *wavefieldDP, float *wavefieldDM) {
+    Prop3DAcoTTIDenQ_DEO2_FDTD *pc = reinterpret_cast<Prop3DAcoTTIDenQ_DEO2_FDTD *>(p);
+    pc->adjointBornAccumulation_V(dVel, wavefieldDP, wavefieldDM);
+}
+
+void Prop3DAcoTTIDenQ_DEO2_FDTD_AdjointBornAccumulation_wavefieldsep_V(
+        void *p, float *dVel, float *wavefieldDP, float *wavefieldDM, const long isFWI) {
+    Prop3DAcoTTIDenQ_DEO2_FDTD *pc = reinterpret_cast<Prop3DAcoTTIDenQ_DEO2_FDTD *>(p);
+    pc->adjointBornAccumulation_wavefieldsep_V(dVel, wavefieldDP, wavefieldDM, isFWI);
+}
+
+void Prop3DAcoTTIDenQ_DEO2_FDTD_AdjointBornAccumulation_VEA(
+        void *p, float *dVel, float *dEps, float *dEta,
+        float *wavefieldP, float *wavefieldM, float *wavefieldDP, float *wavefieldDM) {
+    Prop3DAcoTTIDenQ_DEO2_FDTD *pc = reinterpret_cast<Prop3DAcoTTIDenQ_DEO2_FDTD *>(p);
+    pc->adjointBornAccumulation_VEA(dVel, dEps, dEta, wavefieldP, wavefieldM, wavefieldDP, wavefieldDM);
 }
 
 long Prop3DAcoTTIDenQ_DEO2_FDTD_getNx(void *p) {
@@ -174,26 +177,6 @@ float * Prop3DAcoTTIDenQ_DEO2_FDTD_getMCur(void *p) {
 float * Prop3DAcoTTIDenQ_DEO2_FDTD_getMOld(void *p) {
     Prop3DAcoTTIDenQ_DEO2_FDTD *pc = reinterpret_cast<Prop3DAcoTTIDenQ_DEO2_FDTD *>(p);
     return pc->_mOld;
-}
-
-float * Prop3DAcoTTIDenQ_DEO2_FDTD_getTmpPg1(void *p) {
-    Prop3DAcoTTIDenQ_DEO2_FDTD *pc = reinterpret_cast<Prop3DAcoTTIDenQ_DEO2_FDTD *>(p);
-    return pc->_tmpPg1a;
-}
-
-float * Prop3DAcoTTIDenQ_DEO2_FDTD_getTmpPg3(void *p) {
-    Prop3DAcoTTIDenQ_DEO2_FDTD *pc = reinterpret_cast<Prop3DAcoTTIDenQ_DEO2_FDTD *>(p);
-    return pc->_tmpPg3a;
-}
-
-float * Prop3DAcoTTIDenQ_DEO2_FDTD_getTmpMg1(void *p) {
-    Prop3DAcoTTIDenQ_DEO2_FDTD *pc = reinterpret_cast<Prop3DAcoTTIDenQ_DEO2_FDTD *>(p);
-    return pc->_tmpMg1a;
-}
-
-float * Prop3DAcoTTIDenQ_DEO2_FDTD_getTmpMg3(void *p) {
-    Prop3DAcoTTIDenQ_DEO2_FDTD *pc = reinterpret_cast<Prop3DAcoTTIDenQ_DEO2_FDTD *>(p);
-    return pc->_tmpMg3a;
 }
 
 }

--- a/src/prop3DAcoTTIDenQ_DEO2_FDTD.jl
+++ b/src/prop3DAcoTTIDenQ_DEO2_FDTD.jl
@@ -3,11 +3,11 @@ mutable struct Prop3DAcoTTIDenQ_DEO2_FDTD
 end
 
 function Prop3DAcoTTIDenQ_DEO2_FDTD(;
-        nz,
-        ny,
-        nx,
+        nz=0,
+        ny=0,
+        nx=0,
         nsponge=60,
-        nbz=256,
+        nbz=512,
         nby=8,
         nbx=8,
         dz=5.0,
@@ -21,6 +21,15 @@ function Prop3DAcoTTIDenQ_DEO2_FDTD(;
         qInterior=100.0)
     nz,ny,nx,nsponge,nbz,nby,nbx,nthreads = map(x->round(Int,x), (nz,ny,nx,nsponge,nbz,nby,nbx,nthreads))
     dz,dy,dx,dt = map(x->Float32(x), (dz,dy,dx,dt))
+
+    @assert nx > 0
+    @assert ny > 0
+    @assert nz > 0
+    @assert nsponge > 0
+    @assert nthreads > 0
+    @assert nbx > 0
+    @assert nby > 0
+    @assert nbz > 0
 
     fs = freesurface ? 1 : 0
 
@@ -46,8 +55,8 @@ function size(prop::Prop3DAcoTTIDenQ_DEO2_FDTD)
     (nz,ny,nx)
 end
 
-for _f in (:V, :Eps, :Eta, :SinTheta, :CosTheta, :SinPhi, :CosPhi, :B, :F, :PSpace, :MSpace, :PCur, :POld, :MCur, :MOld, :TmpPg1, :TmpPg3, :TmpMg1, :TmpMg3, :DtOmegaInvQ)
-    symf = "Prop3DAcoTTIDenQ_DEO2_FDTD_get" * string(_f)
+for _f in (:V, :Eps, :Eta, :B, :F, :PSpace, :MSpace, :PCur, :POld, :MCur, :MOld, :SinTheta, :CosTheta, :SinPhi, :CosPhi, :DtOmegaInvQ)
+        symf = "Prop3DAcoTTIDenQ_DEO2_FDTD_get" * string(_f)
     @eval $(_f)(prop::Prop3DAcoTTIDenQ_DEO2_FDTD) = unsafe_wrap(Array, ccall(($symf, libprop3DAcoTTIDenQ_DEO2_FDTD), Ptr{Float32}, (Ptr{Cvoid},), prop.p), size(prop), own=false)
 end
 
@@ -58,33 +67,49 @@ scale_spatial_derivatives!(prop::Prop3DAcoTTIDenQ_DEO2_FDTD) =
     ccall((:Prop3DAcoTTIDenQ_DEO2_FDTD_ScaleSpatialDerivatives, libprop3DAcoTTIDenQ_DEO2_FDTD), Cvoid, (Ptr{Cvoid},), prop.p)
 
 abstract type Prop3DAcoTTIDenQ_DEO2_FDTD_Model end
-
-# v,ϵ,η
 struct Prop3DAcoTTIDenQ_DEO2_FDTD_Model_VEA <: Prop3DAcoTTIDenQ_DEO2_FDTD_Model end
-function forwardBornInjection!(prop::Prop3DAcoTTIDenQ_DEO2_FDTD,modeltype::Prop3DAcoTTIDenQ_DEO2_FDTD_Model_VEA,dmodel,wavefield)
-    ccall((:Prop3DAcoTTIDenQ_DEO2_FDTD_ForwardBornInjection_VEA, libprop3DAcoTTIDenQ_DEO2_FDTD), Cvoid,
-        (Ptr{Cvoid}, Ptr{Cfloat}, Ptr{Cfloat}, Ptr{Cfloat}, Ptr{Cfloat},       Ptr{Cfloat},       Ptr{Cfloat},         Ptr{Cfloat}),
-         prop.p,     dmodel["v"], dmodel["ϵ"], dmodel["η"], wavefield["pold"], wavefield["mold"], wavefield["pspace"], wavefield["mspace"])
-end
-
-function adjointBornAccumulation!(prop::Prop3DAcoTTIDenQ_DEO2_FDTD,modeltype::Prop3DAcoTTIDenQ_DEO2_FDTD_Model_VEA,dmodel,wavefield)
-    ccall((:Prop3DAcoTTIDenQ_DEO2_FDTD_AdjointBornAccumulation_VEA, libprop3DAcoTTIDenQ_DEO2_FDTD), Cvoid,
-        (Ptr{Cvoid}, Ptr{Cfloat}, Ptr{Cfloat}, Ptr{Cfloat}, Ptr{Cfloat},       Ptr{Cfloat},       Ptr{Cfloat},         Ptr{Cfloat}),
-         prop.p,     dmodel["v"], dmodel["ϵ"], dmodel["η"], wavefield["pold"], wavefield["mold"], wavefield["pspace"], wavefield["mspace"])
-end
-
-# v
 struct Prop3DAcoTTIDenQ_DEO2_FDTD_Model_V <: Prop3DAcoTTIDenQ_DEO2_FDTD_Model end
-function forwardBornInjection!(prop::Prop3DAcoTTIDenQ_DEO2_FDTD,modeltype::Prop3DAcoTTIDenQ_DEO2_FDTD_Model_V,dmodel,wavefield)
-    ccall((:Prop3DAcoTTIDenQ_DEO2_FDTD_ForwardBornInjection_V, libprop3DAcoTTIDenQ_DEO2_FDTD), Cvoid,
-        (Ptr{Cvoid}, Ptr{Cfloat}, Ptr{Cfloat},         Ptr{Cfloat}),
-         prop.p,     dmodel["v"], wavefield["pspace"], wavefield["mspace"])
+
+# v,ϵ and η in model-space
+function forwardBornInjection!(prop::Prop3DAcoTTIDenQ_DEO2_FDTD, modeltype::Prop3DAcoTTIDenQ_DEO2_FDTD_Model_VEA, dmodel, wavefields)
+    ccall((:Prop3DAcoTTIDenQ_DEO2_FDTD_ForwardBornInjection_VEA, libprop3DAcoTTIDenQ_DEO2_FDTD), Cvoid,
+        (Ptr{Cvoid}, Ptr{Cfloat}, Ptr{Cfloat}, Ptr{Cfloat}, Ptr{Cfloat},        Ptr{Cfloat},        Ptr{Cfloat},          Ptr{Cfloat}),
+         prop.p,     dmodel["v"], dmodel["ϵ"], dmodel["η"], wavefields["pold"], wavefields["mold"], wavefields["pspace"], wavefields["mspace"])
 end
 
-function adjointBornAccumulation!(prop::Prop3DAcoTTIDenQ_DEO2_FDTD,modeltype::Prop3DAcoTTIDenQ_DEO2_FDTD_Model_V,dmodel,wavefield)
+function adjointBornAccumulation!(prop::Prop3DAcoTTIDenQ_DEO2_FDTD, modeltype::Prop3DAcoTTIDenQ_DEO2_FDTD_Model_VEA, 
+        imagingcondition::ImagingConditionStandard, dmodel, wavefields)
+    ccall((:Prop3DAcoTTIDenQ_DEO2_FDTD_AdjointBornAccumulation_VEA, libprop3DAcoTTIDenQ_DEO2_FDTD), Cvoid,
+        (Ptr{Cvoid}, Ptr{Cfloat}, Ptr{Cfloat}, Ptr{Cfloat}, Ptr{Cfloat},        Ptr{Cfloat},        Ptr{Cfloat},          Ptr{Cfloat}),
+         prop.p,     dmodel["v"], dmodel["ϵ"], dmodel["η"], wavefields["pold"], wavefields["mold"], wavefields["pspace"], wavefields["mspace"])
+end
+
+# v in model-space
+function forwardBornInjection!(prop::Prop3DAcoTTIDenQ_DEO2_FDTD, modeltype::Prop3DAcoTTIDenQ_DEO2_FDTD_Model_V, dmodel, wavefields)
+    ccall((:Prop3DAcoTTIDenQ_DEO2_FDTD_ForwardBornInjection_V, libprop3DAcoTTIDenQ_DEO2_FDTD), Cvoid,
+        (Ptr{Cvoid}, Ptr{Cfloat}, Ptr{Cfloat},          Ptr{Cfloat}),
+         prop.p,     dmodel["v"], wavefields["pspace"], wavefields["mspace"])
+end
+
+function adjointBornAccumulation!(prop::Prop3DAcoTTIDenQ_DEO2_FDTD, modeltype::Prop3DAcoTTIDenQ_DEO2_FDTD_Model_V, 
+        imagingcondition::ImagingConditionStandard, dmodel, wavefields)
     ccall((:Prop3DAcoTTIDenQ_DEO2_FDTD_AdjointBornAccumulation_V, libprop3DAcoTTIDenQ_DEO2_FDTD), Cvoid,
-        (Ptr{Cvoid}, Ptr{Cfloat}, Ptr{Cfloat},         Ptr{Cfloat}),
-         prop.p,     dmodel["v"], wavefield["pspace"], wavefield["mspace"])
+        (Ptr{Cvoid}, Ptr{Cfloat}, Ptr{Cfloat},          Ptr{Cfloat}),
+         prop.p,     dmodel["v"], wavefields["pspace"], wavefields["mspace"])
+end
+
+function adjointBornAccumulation!(prop::Prop3DAcoTTIDenQ_DEO2_FDTD, modeltype::Prop3DAcoTTIDenQ_DEO2_FDTD_Model_V, 
+        imagingcondition::ImagingConditionWaveFieldSeparationFWI, dmodel, wavefields)
+    ccall((:Prop3DAcoTTIDenQ_DEO2_FDTD_AdjointBornAccumulation_wavefieldsep_V, libprop3DAcoTTIDenQ_DEO2_FDTD), Cvoid,
+        (Ptr{Cvoid}, Ptr{Cfloat}, Ptr{Cfloat},          Ptr{Cfloat},          Clong),
+         prop.p,     dmodel["v"], wavefields["pspace"], wavefields["mspace"], 1)
+end
+
+function adjointBornAccumulation!(prop::Prop3DAcoTTIDenQ_DEO2_FDTD, modeltype::Prop3DAcoTTIDenQ_DEO2_FDTD_Model_V, 
+        imagingcondition::ImagingConditionWaveFieldSeparationRTM, dmodel, wavefields)
+    ccall((:Prop3DAcoTTIDenQ_DEO2_FDTD_AdjointBornAccumulation_wavefieldsep_V, libprop3DAcoTTIDenQ_DEO2_FDTD), Cvoid,
+        (Ptr{Cvoid}, Ptr{Cfloat}, Ptr{Cfloat},          Ptr{Cfloat},          Clong),
+         prop.p,     dmodel["v"], wavefields["pspace"], wavefields["mspace"], 0)
 end
 
 function show(io::IO, prop::Prop3DAcoTTIDenQ_DEO2_FDTD)

--- a/src/prop3DAcoVTIDenQ_DEO2_FDTD.cc
+++ b/src/prop3DAcoVTIDenQ_DEO2_FDTD.cc
@@ -17,11 +17,10 @@ void *Prop3DAcoVTIDenQ_DEO2_FDTD_alloc(
         long nbx,
         long nby,
         long nbz) {
-
     bool freeSurface = (fs > 0) ? true : false;
 
     Prop3DAcoVTIDenQ_DEO2_FDTD *p = new Prop3DAcoVTIDenQ_DEO2_FDTD(
-            freeSurface, nthread, nx, ny, nz, nsponge, dx, dy, dz, dt, nbx, nby, nbz);
+        freeSurface, nthread, nx, ny, nz, nsponge, dx, dy, dz, dt, nbx, nby, nbz);
 
     return (void*) p;
 }
@@ -43,14 +42,14 @@ void Prop3DAcoVTIDenQ_DEO2_FDTD_SetupDtOmegaInvQ(void *p, float freqQ, float qMi
     setupDtOmegaInvQ_3D(fs, nx, ny, nz, nsponge, nthread, dt, freqQ, qMin, qInterior, pc->_dtOmegaInvQ);
 }
 
-void Prop3DAcoVTIDenQ_DEO2_FDTD_TimeStep(void *p) {
-    Prop3DAcoVTIDenQ_DEO2_FDTD *pc = reinterpret_cast<Prop3DAcoVTIDenQ_DEO2_FDTD *>(p);
-    pc->timeStep();
-}
-
 void Prop3DAcoVTIDenQ_DEO2_FDTD_TimeStepLinear(void *p) {
     Prop3DAcoVTIDenQ_DEO2_FDTD *pc = reinterpret_cast<Prop3DAcoVTIDenQ_DEO2_FDTD *>(p);
     pc->timeStepLinear();
+}
+
+void Prop3DAcoVTIDenQ_DEO2_FDTD_TimeStep(void *p) {
+    Prop3DAcoVTIDenQ_DEO2_FDTD *pc = reinterpret_cast<Prop3DAcoVTIDenQ_DEO2_FDTD *>(p);
+    pc->timeStep();
 }
 
 void Prop3DAcoVTIDenQ_DEO2_FDTD_ScaleSpatialDerivatives(void *p) {
@@ -58,32 +57,36 @@ void Prop3DAcoVTIDenQ_DEO2_FDTD_ScaleSpatialDerivatives(void *p) {
     pc->scaleSpatialDerivatives();
 }
 
-void Prop3DAcoVTIDenQ_DEO2_FDTD_ForwardBornInjection_VEA(void *p,
-        float *dmodelV, float *dmodelE, float *dmodelA,
+void Prop3DAcoVTIDenQ_DEO2_FDTD_ForwardBornInjection_V(
+        void *p, float *dVel, float *wavefieldDP, float *wavefieldDM) {
+    Prop3DAcoVTIDenQ_DEO2_FDTD *pc = reinterpret_cast<Prop3DAcoVTIDenQ_DEO2_FDTD *>(p);
+    pc->forwardBornInjection_V(dVel, wavefieldDP, wavefieldDM);
+}
+
+void Prop3DAcoVTIDenQ_DEO2_FDTD_ForwardBornInjection_VEA(
+        void *p, float *dVel, float *dEps, float *dEta,
         float *wavefieldP, float *wavefieldM, float *wavefieldDP, float *wavefieldDM) {
     Prop3DAcoVTIDenQ_DEO2_FDTD *pc = reinterpret_cast<Prop3DAcoVTIDenQ_DEO2_FDTD *>(p);
-    pc->forwardBornInjection_VEA(dmodelV, dmodelE, dmodelA, wavefieldP, wavefieldM, wavefieldDP, wavefieldDM);
+    pc->forwardBornInjection_VEA(dVel, dEps, dEta, wavefieldP, wavefieldM, wavefieldDP, wavefieldDM);
 }
 
-void Prop3DAcoVTIDenQ_DEO2_FDTD_ForwardBornInjection_V(void *p,
-        float *dmodelV,
-        float *wavefieldDP, float *wavefieldDM) {
+void Prop3DAcoVTIDenQ_DEO2_FDTD_AdjointBornAccumulation_V(
+        void *p, float *dVel, float *wavefieldDP, float *wavefieldDM) {
     Prop3DAcoVTIDenQ_DEO2_FDTD *pc = reinterpret_cast<Prop3DAcoVTIDenQ_DEO2_FDTD *>(p);
-    pc->forwardBornInjection_V(dmodelV, wavefieldDP, wavefieldDM);
+    pc->adjointBornAccumulation_V(dVel, wavefieldDP, wavefieldDM);
 }
 
-void Prop3DAcoVTIDenQ_DEO2_FDTD_AdjointBornAccumulation_VEA(void *p,
-        float *dmodelV, float *dmodelE, float *dmodelA,
+void Prop3DAcoVTIDenQ_DEO2_FDTD_AdjointBornAccumulation_wavefieldsep_V(
+        void *p, float *dVel, float *wavefieldDP, float *wavefieldDM, const long isFWI) {
+    Prop3DAcoVTIDenQ_DEO2_FDTD *pc = reinterpret_cast<Prop3DAcoVTIDenQ_DEO2_FDTD *>(p);
+    pc->adjointBornAccumulation_wavefieldsep_V(dVel, wavefieldDP, wavefieldDM, isFWI);
+}
+
+void Prop3DAcoVTIDenQ_DEO2_FDTD_AdjointBornAccumulation_VEA(
+        void *p, float *dVel, float *dEps, float *dEta,
         float *wavefieldP, float *wavefieldM, float *wavefieldDP, float *wavefieldDM) {
     Prop3DAcoVTIDenQ_DEO2_FDTD *pc = reinterpret_cast<Prop3DAcoVTIDenQ_DEO2_FDTD *>(p);
-    pc->adjointBornAccumulation_VEA(dmodelV, dmodelE, dmodelA, wavefieldP, wavefieldM, wavefieldDP, wavefieldDM);
-}
-
-void Prop3DAcoVTIDenQ_DEO2_FDTD_AdjointBornAccumulation_V(void *p,
-        float *dmodelV,
-        float *wavefieldDP, float *wavefieldDM) {
-    Prop3DAcoVTIDenQ_DEO2_FDTD *pc = reinterpret_cast<Prop3DAcoVTIDenQ_DEO2_FDTD *>(p);
-    pc->adjointBornAccumulation_V(dmodelV, wavefieldDP, wavefieldDM);
+    pc->adjointBornAccumulation_VEA(dVel, dEps, dEta, wavefieldP, wavefieldM, wavefieldDP, wavefieldDM);
 }
 
 long Prop3DAcoVTIDenQ_DEO2_FDTD_getNx(void *p) {

--- a/src/prop3DAcoVTIDenQ_DEO2_FDTD.h
+++ b/src/prop3DAcoVTIDenQ_DEO2_FDTD.h
@@ -6,8 +6,8 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <math.h>
-
-#include "absorb.h"
+#include <fftw3.h>
+#include <complex>
 
 #define MIN(x,y) ((x)<(y)?(x):(y))
 
@@ -46,39 +46,39 @@ public:
     float * _mCur = NULL;
 
     Prop3DAcoVTIDenQ_DEO2_FDTD(
-            bool freeSurface,
-            long nthread,
-            long nx,
-            long ny,
-            long nz,
-            long nsponge,
-            float dx,
-            float dy,
-            float dz,
-            float dt,
-            const long nbx,
-            const long nby,
-            const long nbz) :
-                _freeSurface(freeSurface),
-                _nthread(nthread),
-                _nx(nx),
-                _ny(ny),
-                _nz(nz),
-                _nsponge(nsponge),
-                _nbx(nbx),
-                _nby(nby),
-                _nbz(nbz),
-                _dx(dx),
-                _dy(dy),
-                _dz(dz),
-                _dt(dt),
-                _c8_1(+1225.0 / 1024.0),
-                _c8_2(-245.0 / 3072.0),
-                _c8_3(+49.0 / 5120.0),
-                _c8_4(-5.0 / 7168.0),
-                _invDx(1.0 / _dx),
-                _invDy(1.0 / _dy),
-                _invDz(1.0 / _dz) {
+        bool freeSurface,
+        long nthread,
+        long nx,
+        long ny,
+        long nz,
+        long nsponge,
+        float dx,
+        float dy,
+        float dz,
+        float dt,
+        const long nbx,
+        const long nby,
+        const long nbz) :
+            _freeSurface(freeSurface),
+            _nthread(nthread),
+            _nx(nx),
+            _ny(ny),
+            _nz(nz),
+            _nsponge(nsponge),
+            _nbx(nbx),
+            _nby(nby),
+            _nbz(nbz),
+            _dx(dx),
+            _dy(dy),
+            _dz(dz),
+            _dt(dt),
+            _c8_1(+1225.0 / 1024.0),
+            _c8_2(-245.0 / 3072.0),
+            _c8_3(+49.0 / 5120.0),
+            _c8_4(-5.0 / 7168.0),
+            _invDx(1.0 / _dx),
+            _invDy(1.0 / _dy),
+            _invDz(1.0 / _dz) {
 
         // Allocate arrays
         _v           = new float[_nx * _ny * _nz];
@@ -107,10 +107,10 @@ public:
         _mCur        = new float[_nx * _ny * _nz];
 
         numaFirstTouch(_nx, _ny, _nz, _nthread, _v, _eps, _eta, _b,
-            _f, _dtOmegaInvQ, _pSpace, _mSpace, _tmpPx1, _tmpPy1,
-            _tmpPz1, _tmpMx1, _tmpMy1, _tmpMz1, _tmpPx2, _tmpPy2, _tmpPz2,
-            _tmpMx2, _tmpMy2, _tmpMz2, _pOld, _pCur, _mOld, _mCur, _nbx, _nby,
-            _nbz);
+            _f, _dtOmegaInvQ, _pSpace, _mSpace, 
+            _tmpPx1, _tmpPy1, _tmpPz1, _tmpMx1, _tmpMy1, _tmpMz1, 
+            _tmpPx2, _tmpPy2, _tmpPz2, _tmpMx2, _tmpMy2, _tmpMz2, 
+            _pOld, _pCur, _mOld, _mCur, _nbx, _nby, _nbz);
     }
 
 #if defined(__FUNCTION_CLONES__)
@@ -407,8 +407,6 @@ __attribute__((target_clones("avx","avx2","avx512f","default")))
     /**
      * Add the Born source at the current time
      *
-     * Note: "dmodelV,dmodelE,dmodelA" are the three components of the model [vel,eps,eta]
-     *
      * User must have:
      *   - called the nonlinear forward
      *   - saved 2nd time derivative of pressure at corresponding time index in array dp2
@@ -417,9 +415,7 @@ __attribute__((target_clones("avx","avx2","avx512f","default")))
 #if defined(__FUNCTION_CLONES__)
 __attribute__((target_clones("avx","avx2","avx512f","default")))
 #endif
-    inline void forwardBornInjection_V(
-            float *dmodelV,
-            float *wavefieldDP, float *wavefieldDM) {
+    inline void forwardBornInjection_V(float *dVel, float *wavefieldDP, float *wavefieldDM) {
 #pragma omp parallel for collapse(3) num_threads(_nthread) schedule(static)
         for (long bx = 0; bx < _nx; bx += _nbx) {
             for (long by = 0; by < _ny; by += _nby) {
@@ -436,7 +432,7 @@ __attribute__((target_clones("avx","avx2","avx512f","default")))
 
                                 const float V  = _v[k];
                                 const float B  = _b[k];
-                                const float dV = dmodelV[k];
+                                const float dV = dVel[k];
 
                                 // V^2/b factor to "clear" the b/V^2 factor on L_tP and L_tM
                                 // _dt^2 factor is from the finite difference approximation
@@ -456,8 +452,7 @@ __attribute__((target_clones("avx","avx2","avx512f","default")))
 #if defined(__FUNCTION_CLONES__)
 __attribute__((target_clones("avx","avx2","avx512f","default")))
 #endif
-    inline void forwardBornInjection_VEA(
-            float *dmodelV, float *dmodelE, float *dmodelA,
+    inline void forwardBornInjection_VEA(float *dVel, float *dEps, float *dEta,
             float *wavefieldP, float *wavefieldM, float *wavefieldDP, float *wavefieldDM) {
 
         // Right side spatial derivatives for the Born source
@@ -491,9 +486,9 @@ __attribute__((target_clones("avx","avx2","avx512f","default")))
                                 const float B  = _b[k];
                                 const float F  = _f[k];
 
-                                const float dV = dmodelV[k];
-                                const float dE = dmodelE[k];
-                                const float dA = dmodelA[k];
+                                const float dV = dVel[k];
+                                const float dE = dEps[k];
+                                const float dA = dEta[k];
 
                                 _tmpPx2[k] = (+2 * B * dE) *_tmpPx1[k];
                                 _tmpPy2[k] = (+2 * B * dE) *_tmpPy1[k];
@@ -537,7 +532,7 @@ __attribute__((target_clones("avx","avx2","avx512f","default")))
 
                                 const float V  = _v[k];
                                 const float B  = _b[k];
-                                const float dV = dmodelV[k];
+                                const float dV = dVel[k];
 
                                 const float dt2v2OverB = _dt * _dt * V * V / B;
 
@@ -556,8 +551,6 @@ __attribute__((target_clones("avx","avx2","avx512f","default")))
     /**
      * Accumulate the Born image term at the current time
      *
-     * Note: "dmodelV,dmodelE,dmodelA" are the three components of the model [vel,eps,eta]
-     *
      * User must have:
      *   - called the nonlinear forward
      *   - saved 2nd time derivative of pressure at corresponding time index in array dp2
@@ -566,7 +559,7 @@ __attribute__((target_clones("avx","avx2","avx512f","default")))
 #if defined(__FUNCTION_CLONES__)
 __attribute__((target_clones("avx","avx2","avx512f","default")))
 #endif
-    inline void adjointBornAccumulation_V(float *dmodelV,
+    inline void adjointBornAccumulation_V(float *dVel,
             float *wavefieldDP, float *wavefieldDM) {
 #pragma omp parallel for collapse(3) num_threads(_nthread) schedule(static)
         for (long bx = 0; bx < _nx; bx += _nbx) {
@@ -581,13 +574,10 @@ __attribute__((target_clones("avx","avx2","avx512f","default")))
 #pragma omp simd
                             for (long kz = bz; kz < kzmax; kz++) {
                                 const long k = kx * _ny * _nz + ky * _nz + kz;
-
                                 const float V = _v[k];
                                 const float B = _b[k];
-
                                 const float factor = 2 * B / (V * V * V);
-
-                                dmodelV[k] += factor * (wavefieldDP[k] * _pOld[k] + wavefieldDM[k] * _mOld[k]);
+                                dVel[k] += factor * (wavefieldDP[k] * _pOld[k] + wavefieldDM[k] * _mOld[k]);
                             }
                         }
                     }
@@ -596,10 +586,146 @@ __attribute__((target_clones("avx","avx2","avx512f","default")))
         }
     }
 
+    /**
+     * Apply Kz wavenumber filter for up/down wavefield seperation
+     * Faqi, 2011, Geophysics https://library.seg.org/doi/full/10.1190/1.3533914
+     * 
+     * We handle the FWI and RTM imaging conditions with a condition inside the OMP loop
+     * 
+     * Example Kz filtering with 8 samples 
+     * frequency | +0 | +1 | +2 | +3 |  N | -3 | -2 | -1 |
+     * original  |  0 |  1 |  2 |  3 |  4 |  5 |  6 |  7 |
+     * upgoing   |  0 |  X |  X |  X |  4 |  5 |  6 |  7 |
+     * dngoing   |  0 |  1 |  2 |  3 |  4 |  X |  X |  X |
+     */
 #if defined(__FUNCTION_CLONES__)
 __attribute__((target_clones("avx","avx2","avx512f","default")))
 #endif
-    inline void adjointBornAccumulation_VEA(float *dmodelV, float *dmodelE, float *dmodelA,
+     inline void adjointBornAccumulation_wavefieldsep_V(float *dVel, 
+            float *wavefieldDP, float *wavefieldDM, const long isFWI) {
+        const long nfft = 2 * _nz;
+        const float scale = 1.0f / (float)(nfft);
+
+        // FWI: adj wavefield is dngoing
+        // RTM: adj wavefield is upgoing
+        const long kfft_adj = (isFWI) ? 0 : nfft / 2;
+
+        std::complex<float> * __restrict__ tmp = new std::complex<float>[nfft];
+
+        fftwf_plan planForward = fftwf_plan_dft_1d(nfft,
+            reinterpret_cast<fftwf_complex*>(tmp),
+            reinterpret_cast<fftwf_complex*>(tmp), +1, FFTW_ESTIMATE);
+
+        fftwf_plan planInverse = fftwf_plan_dft_1d(nfft,
+            reinterpret_cast<fftwf_complex*>(tmp),
+            reinterpret_cast<fftwf_complex*>(tmp), -1, FFTW_ESTIMATE);
+
+        delete [] tmp;
+
+#pragma omp parallel num_threads(_nthread)
+        {
+            std::complex<float> * __restrict__ tmp_nlf_p = new std::complex<float>[nfft];
+            std::complex<float> * __restrict__ tmp_adj_p = new std::complex<float>[nfft];
+            std::complex<float> * __restrict__ tmp_nlf_m = new std::complex<float>[nfft];
+            std::complex<float> * __restrict__ tmp_adj_m = new std::complex<float>[nfft];
+
+#pragma omp for collapse(2) schedule(static)
+        for (long bx = 0; bx < _nx; bx += _nbx) {
+            for (long by = 0; by < _ny; by += _nby) {
+                const long kxmax = MIN(bx + _nbx, _nx);
+                const long kymax = MIN(by + _nby, _ny);
+
+                for (long kx = bx; kx < kxmax; kx++) {
+                    for (long ky = by; ky < kymax; ky++) {
+#pragma omp simd
+                        for (long kfft = 0; kfft < nfft; kfft++) {
+                            tmp_nlf_p[kfft] = 0;
+                            tmp_adj_p[kfft] = 0;
+                            tmp_nlf_m[kfft] = 0;
+                            tmp_adj_m[kfft] = 0;
+                        }  
+
+#pragma omp simd
+                        for (long kz = 0; kz < _nz; kz++) {
+                            const long k = kx * _ny * _nz + ky * _nz + kz;
+                            tmp_nlf_p[kz] = scale * wavefieldDP[k];
+                            tmp_adj_p[kz] = scale * _pOld[k];
+                            tmp_nlf_m[kz] = scale * wavefieldDM[k];
+                            tmp_adj_m[kz] = scale * _mOld[k];
+                        }  
+
+                        fftwf_execute_dft(planForward,
+                            reinterpret_cast<fftwf_complex*>(tmp_nlf_p),
+                            reinterpret_cast<fftwf_complex*>(tmp_nlf_p));
+
+                        fftwf_execute_dft(planForward,
+                            reinterpret_cast<fftwf_complex*>(tmp_adj_p),
+                            reinterpret_cast<fftwf_complex*>(tmp_adj_p));
+
+                        fftwf_execute_dft(planForward,
+                            reinterpret_cast<fftwf_complex*>(tmp_nlf_m),
+                            reinterpret_cast<fftwf_complex*>(tmp_nlf_m));
+
+                        fftwf_execute_dft(planForward,
+                            reinterpret_cast<fftwf_complex*>(tmp_adj_m),
+                            reinterpret_cast<fftwf_complex*>(tmp_adj_m));
+
+                        // upgoing: zero the positive frequencies, excluding Nyquist
+                        // dngoing: zero the negative frequencies, excluding Nyquist
+#pragma omp simd
+                        for (long k = 1; k < nfft / 2; k++) {
+                            tmp_nlf_p[nfft / 2 + k] = 0;
+                            tmp_adj_p[kfft_adj + k] = 0;
+                            tmp_nlf_m[nfft / 2 + k] = 0;
+                            tmp_adj_m[kfft_adj + k] = 0;
+                        }
+
+                        fftwf_execute_dft(planInverse,
+                            reinterpret_cast<fftwf_complex*>(tmp_nlf_p),
+                            reinterpret_cast<fftwf_complex*>(tmp_nlf_p));
+
+                        fftwf_execute_dft(planInverse,
+                            reinterpret_cast<fftwf_complex*>(tmp_adj_p),
+                            reinterpret_cast<fftwf_complex*>(tmp_adj_p));
+
+                        fftwf_execute_dft(planInverse,
+                            reinterpret_cast<fftwf_complex*>(tmp_nlf_m),
+                            reinterpret_cast<fftwf_complex*>(tmp_nlf_m));
+
+                        fftwf_execute_dft(planInverse,
+                            reinterpret_cast<fftwf_complex*>(tmp_adj_m),
+                            reinterpret_cast<fftwf_complex*>(tmp_adj_m));
+
+                        // Faqi eq 10
+                        // Applied to FWI: [Sup * Rdn]
+                        // Applied to RTM: [Sup * Rup]
+#pragma omp simd
+                        for (long kz = 0; kz < _nz; kz++) {
+                            const long k = kx * _ny * _nz + ky * _nz + kz;
+                            const float V = _v[k];
+                            const float B = _b[k];
+                            const float factor = 2 * B / (V * V * V);
+                            dVel[k] += factor * (real(tmp_nlf_p[kz] * tmp_adj_p[kz]) + real(tmp_nlf_m[kz] * tmp_adj_m[kz]));
+                        }
+                    } // end loop over ky
+                } // end loop over kx
+            } // end loop over by
+        } // end loop over bx
+
+        delete [] tmp_nlf_p;
+        delete [] tmp_adj_p;
+        delete [] tmp_nlf_m;
+        delete [] tmp_adj_m;
+    } // end parallel region
+
+    fftwf_destroy_plan(planForward);
+    fftwf_destroy_plan(planInverse);
+ }
+
+#if defined(__FUNCTION_CLONES__)
+__attribute__((target_clones("avx","avx2","avx512f","default")))
+#endif
+    inline void adjointBornAccumulation_VEA(float *dVel, float *dEps, float *dEta,
             float *wavefieldP, float *wavefieldM, float *wavefieldDP, float *wavefieldDM) {
 
         // Right side spatial derivatives for the adjoint accumulation
@@ -642,14 +768,14 @@ __attribute__((target_clones("avx","avx2","avx512f","default")))
 
                                 const float factor = 2 * B / (V * V * V);
 
-                                dmodelV[k] += factor * (wavefieldDP[k] * _pOld[k] + wavefieldDM[k] * _mOld[k]);
+                                dVel[k] += factor * (wavefieldDP[k] * _pOld[k] + wavefieldDM[k] * _mOld[k]);
 
-                                dmodelE[k] += (-2 * B * _tmpPx1[k] * _tmpPx2[k] -2 * B * _tmpPy1[k] * _tmpPy2[k]);
+                                dEps[k] += (-2 * B * _tmpPx1[k] * _tmpPx2[k] -2 * B * _tmpPy1[k] * _tmpPy2[k]);
 
                                 const float partP = 2 * B * F * A * _tmpPz1[k] - (B * F * (1 - 2 * A * A) / sqrt(1 - A * A)) * _tmpMz1[k];
                                 const float partM = 2 * B * F * A * _tmpMz1[k] + (B * F * (1 - 2 * A * A) / sqrt(1 - A * A)) * _tmpPz1[k];
 
-                                dmodelA[k] += (partP * _tmpPz2[k] - partM * _tmpMz2[k]);
+                                dEta[k] += (partP * _tmpPz2[k] - partM * _tmpMz2[k]);
                             }
                         }
                     }

--- a/src/prop3DAcoVTIDenQ_DEO2_FDTD.jl
+++ b/src/prop3DAcoVTIDenQ_DEO2_FDTD.jl
@@ -3,11 +3,11 @@ mutable struct Prop3DAcoVTIDenQ_DEO2_FDTD
 end
 
 function Prop3DAcoVTIDenQ_DEO2_FDTD(;
-        nz,
-        ny,
-        nx,
+        nz=0,
+        ny=0,
+        nx=0,
         nsponge=60,
-        nbz=256,
+        nbz=512,
         nby=8,
         nbx=8,
         dz=5.0,
@@ -21,6 +21,15 @@ function Prop3DAcoVTIDenQ_DEO2_FDTD(;
         qInterior=100.0)
     nz,ny,nx,nsponge,nbz,nby,nbx,nthreads = map(x->round(Int,x), (nz,ny,nx,nsponge,nbz,nby,nbx,nthreads))
     dz,dy,dx,dt = map(x->Float32(x), (dz,dy,dx,dt))
+
+    @assert nx > 0
+    @assert ny > 0
+    @assert nz > 0
+    @assert nsponge > 0
+    @assert nthreads > 0
+    @assert nbx > 0
+    @assert nby > 0
+    @assert nbz > 0
 
     fs = freesurface ? 1 : 0
 
@@ -46,46 +55,62 @@ function size(prop::Prop3DAcoVTIDenQ_DEO2_FDTD)
     (nz,ny,nx)
 end
 
-for _f in (:V, :Eps, :Eta, :B, :F, :PSpace, :MSpace, :PCur, :POld, :MCur, :MOld)
+for _f in (:V, :Eps, :Eta, :B, :F, :PSpace, :MSpace, :PCur, :POld, :MCur, :MOld, :DtOmegaInvQ)
     symf = "Prop3DAcoVTIDenQ_DEO2_FDTD_get" * string(_f)
     @eval $(_f)(prop::Prop3DAcoVTIDenQ_DEO2_FDTD) = unsafe_wrap(Array, ccall(($symf, libprop3DAcoVTIDenQ_DEO2_FDTD), Ptr{Float32}, (Ptr{Cvoid},), prop.p), size(prop), own=false)
 end
 
-propagateforward!(prop::Prop3DAcoVTIDenQ_DEO2_FDTD) = ccall((:Prop3DAcoVTIDenQ_DEO2_FDTD_TimeStep, libprop3DAcoVTIDenQ_DEO2_FDTD), Cvoid, (Ptr{Cvoid},), prop.p)
 propagateforward_linear!(prop::Prop3DAcoVTIDenQ_DEO2_FDTD) = ccall((:Prop3DAcoVTIDenQ_DEO2_FDTD_TimeStepLinear, libprop3DAcoVTIDenQ_DEO2_FDTD), Cvoid, (Ptr{Cvoid},), prop.p)
+propagateforward!(prop::Prop3DAcoVTIDenQ_DEO2_FDTD) = ccall((:Prop3DAcoVTIDenQ_DEO2_FDTD_TimeStep, libprop3DAcoVTIDenQ_DEO2_FDTD), Cvoid, (Ptr{Cvoid},), prop.p)
 propagateadjoint!(prop::Prop3DAcoVTIDenQ_DEO2_FDTD) = propagateforward_linear!(prop) # self-adjoint
 
 scale_spatial_derivatives!(prop::Prop3DAcoVTIDenQ_DEO2_FDTD) =
     ccall((:Prop3DAcoVTIDenQ_DEO2_FDTD_ScaleSpatialDerivatives, libprop3DAcoVTIDenQ_DEO2_FDTD), Cvoid, (Ptr{Cvoid},), prop.p)
 
 abstract type Prop3DAcoVTIDenQ_DEO2_FDTD_Model end
-
-# v,ϵ,η
 struct Prop3DAcoVTIDenQ_DEO2_FDTD_Model_VEA <: Prop3DAcoVTIDenQ_DEO2_FDTD_Model end
-function forwardBornInjection!(prop::Prop3DAcoVTIDenQ_DEO2_FDTD,modeltype::Prop3DAcoVTIDenQ_DEO2_FDTD_Model_VEA,dmodel,wavefield)
-    ccall((:Prop3DAcoVTIDenQ_DEO2_FDTD_ForwardBornInjection_VEA, libprop3DAcoVTIDenQ_DEO2_FDTD), Cvoid,
-        (Ptr{Cvoid},Ptr{Cfloat}, Ptr{Cfloat}, Ptr{Cfloat}, Ptr{Cfloat},       Ptr{Cfloat},       Ptr{Cfloat},         Ptr{Cfloat}),
-         prop.p,    dmodel["v"], dmodel["ϵ"], dmodel["η"], wavefield["pold"], wavefield["mold"], wavefield["pspace"], wavefield["mspace"])
-end
-
-function adjointBornAccumulation!(prop::Prop3DAcoVTIDenQ_DEO2_FDTD,modeltype::Prop3DAcoVTIDenQ_DEO2_FDTD_Model_VEA,dmodel,wavefield)
-    ccall((:Prop3DAcoVTIDenQ_DEO2_FDTD_AdjointBornAccumulation_VEA, libprop3DAcoVTIDenQ_DEO2_FDTD), Cvoid,
-        (Ptr{Cvoid},Ptr{Cfloat}, Ptr{Cfloat}, Ptr{Cfloat}, Ptr{Cfloat},       Ptr{Cfloat},       Ptr{Cfloat},         Ptr{Cfloat}),
-         prop.p,    dmodel["v"], dmodel["ϵ"], dmodel["η"], wavefield["pold"], wavefield["mold"], wavefield["pspace"], wavefield["mspace"])
-end
-
-# v
 struct Prop3DAcoVTIDenQ_DEO2_FDTD_Model_V <: Prop3DAcoVTIDenQ_DEO2_FDTD_Model end
-function forwardBornInjection!(prop::Prop3DAcoVTIDenQ_DEO2_FDTD,modeltype::Prop3DAcoVTIDenQ_DEO2_FDTD_Model_V,dmodel,wavefield)
-    ccall((:Prop3DAcoVTIDenQ_DEO2_FDTD_ForwardBornInjection_V, libprop3DAcoVTIDenQ_DEO2_FDTD), Cvoid,
-        (Ptr{Cvoid},Ptr{Cfloat}, Ptr{Cfloat},         Ptr{Cfloat}),
-         prop.p,    dmodel["v"], wavefield["pspace"], wavefield["mspace"])
+
+# v,ϵ and η in model-space
+function forwardBornInjection!(prop::Prop3DAcoVTIDenQ_DEO2_FDTD, modeltype::Prop3DAcoVTIDenQ_DEO2_FDTD_Model_VEA, dmodel, wavefields)
+    ccall((:Prop3DAcoVTIDenQ_DEO2_FDTD_ForwardBornInjection_VEA, libprop3DAcoVTIDenQ_DEO2_FDTD), Cvoid,
+        (Ptr{Cvoid}, Ptr{Cfloat}, Ptr{Cfloat}, Ptr{Cfloat}, Ptr{Cfloat},        Ptr{Cfloat},        Ptr{Cfloat},          Ptr{Cfloat}),
+         prop.p,     dmodel["v"], dmodel["ϵ"], dmodel["η"], wavefields["pold"], wavefields["mold"], wavefields["pspace"], wavefields["mspace"])
 end
 
-function adjointBornAccumulation!(prop::Prop3DAcoVTIDenQ_DEO2_FDTD,modeltype::Prop3DAcoVTIDenQ_DEO2_FDTD_Model_V,dmodel,wavefield)
+function adjointBornAccumulation!(prop::Prop3DAcoVTIDenQ_DEO2_FDTD, modeltype::Prop3DAcoVTIDenQ_DEO2_FDTD_Model_VEA, 
+        imagingcondition::ImagingConditionStandard, dmodel, wavefields)
+    ccall((:Prop3DAcoVTIDenQ_DEO2_FDTD_AdjointBornAccumulation_VEA, libprop3DAcoVTIDenQ_DEO2_FDTD), Cvoid, 
+        (Ptr{Cvoid}, Ptr{Cfloat}, Ptr{Cfloat}, Ptr{Cfloat}, Ptr{Cfloat},        Ptr{Cfloat},        Ptr{Cfloat},          Ptr{Cfloat}),
+         prop.p,     dmodel["v"], dmodel["ϵ"], dmodel["η"], wavefields["pold"], wavefields["mold"], wavefields["pspace"], wavefields["mspace"])
+end
+
+# v in model-space
+function forwardBornInjection!(prop::Prop3DAcoVTIDenQ_DEO2_FDTD, modeltype::Prop3DAcoVTIDenQ_DEO2_FDTD_Model_V, dmodel, wavefields)
+    ccall((:Prop3DAcoVTIDenQ_DEO2_FDTD_ForwardBornInjection_V, libprop3DAcoVTIDenQ_DEO2_FDTD), Cvoid,
+        (Ptr{Cvoid}, Ptr{Cfloat}, Ptr{Cfloat},          Ptr{Cfloat}),
+         prop.p,     dmodel["v"], wavefields["pspace"], wavefields["mspace"])
+end
+
+function adjointBornAccumulation!(prop::Prop3DAcoVTIDenQ_DEO2_FDTD, modeltype::Prop3DAcoVTIDenQ_DEO2_FDTD_Model_V, 
+        imagingcondition::ImagingConditionStandard, dmodel, wavefields)
     ccall((:Prop3DAcoVTIDenQ_DEO2_FDTD_AdjointBornAccumulation_V, libprop3DAcoVTIDenQ_DEO2_FDTD), Cvoid,
-        (Ptr{Cvoid}, Ptr{Cfloat}, Ptr{Cfloat},         Ptr{Cfloat}),
-         prop.p,     dmodel["v"], wavefield["pspace"], wavefield["mspace"])
+        (Ptr{Cvoid}, Ptr{Cfloat}, Ptr{Cfloat},          Ptr{Cfloat}),
+         prop.p,     dmodel["v"], wavefields["pspace"], wavefields["mspace"])
+end
+
+function adjointBornAccumulation!(prop::Prop3DAcoVTIDenQ_DEO2_FDTD, modeltype::Prop3DAcoVTIDenQ_DEO2_FDTD_Model_V, 
+        imagingcondition::ImagingConditionWaveFieldSeparationFWI, dmodel, wavefields)
+    ccall((:Prop3DAcoVTIDenQ_DEO2_FDTD_AdjointBornAccumulation_wavefieldsep_V, libprop3DAcoVTIDenQ_DEO2_FDTD), Cvoid,
+        (Ptr{Cvoid}, Ptr{Cfloat}, Ptr{Cfloat},          Ptr{Cfloat},          Clong),
+         prop.p,     dmodel["v"], wavefields["pspace"], wavefields["mspace"], 1)
+end
+
+function adjointBornAccumulation!(prop::Prop3DAcoVTIDenQ_DEO2_FDTD, modeltype::Prop3DAcoVTIDenQ_DEO2_FDTD_Model_V, 
+        imagingcondition::ImagingConditionWaveFieldSeparationRTM, dmodel, wavefields)
+    ccall((:Prop3DAcoVTIDenQ_DEO2_FDTD_AdjointBornAccumulation_wavefieldsep_V, libprop3DAcoVTIDenQ_DEO2_FDTD), Cvoid,
+        (Ptr{Cvoid}, Ptr{Cfloat}, Ptr{Cfloat},          Ptr{Cfloat},          Clong),
+         prop.p,     dmodel["v"], wavefields["pspace"], wavefields["mspace"], 0)
 end
 
 function show(io::IO, prop::Prop3DAcoVTIDenQ_DEO2_FDTD)

--- a/test/imgcondition.jl
+++ b/test/imgcondition.jl
@@ -1,0 +1,133 @@
+using LinearAlgebra, Test, WaveFD
+
+# Unit tests for the 3 types of imaging condition are a little bit heuristic. We construct 
+# the nonlinear and adjoint wavefields with horizontal bars, and test the result.
+#
+# The FWI imaging condition result will be longer spatial wavelength and extend the region 
+# of positive values in the correlation, while the RTM imaging condition result will be 
+# shorter spatial wavelength and introduce negative values.
+#
+# Note these imaging conditions are tested under propagation in JetPackWaveFD.
+dt = 0.001
+dz,dy,dx = 10.0,10.0,10.0
+nz,ny,nx = 51,51,51
+nthreads = Sys.CPU_THREADS
+n = 10
+z0 = div(nz,2)
+z1 = z0 - div(n,2)
+z2 = z0 + div(n,2)
+x0 = div(nx,2)
+
+@testset "ImgCondition" begin
+
+    @testset "Imaging Condition 2D tests, $(physics)" for physics in ("ISO", "VTI", "TTI")
+        if physics == "ISO"
+            piso = WaveFD.Prop2DAcoIsoDenQ_DEO2_FDTD(freesurface=false, nz=nz, nx=nx, dz=dz, dx=dx, dt=dt, nthreads=nthreads)
+            WaveFD.B(piso) .= 1
+            WaveFD.V(piso) .= 1
+            WaveFD.POld(piso)[z1:z2,:] .= 1
+        elseif physics == "VTI"
+            pvti = WaveFD.Prop2DAcoVTIDenQ_DEO2_FDTD(freesurface=false, nz=nz, nx=nx, dz=dz, dx=dx, dt=dt, nthreads=nthreads)
+            WaveFD.B(pvti) .= 1
+            WaveFD.V(pvti) .= 1
+            WaveFD.POld(pvti)[z1:z2,:] .= 1
+            WaveFD.MOld(pvti)[z1:z2,:] .= 2
+        elseif physics == "TTI"
+            ptti = WaveFD.Prop2DAcoTTIDenQ_DEO2_FDTD(freesurface=false, nz=nz, nx=nx, dz=dz, dx=dx, dt=dt, nthreads=nthreads)
+            WaveFD.B(ptti) .= 1
+            WaveFD.V(ptti) .= 1
+            WaveFD.POld(ptti)[z1:z2,:] .= 1
+            WaveFD.MOld(ptti)[z1:z2,:] .= 2
+        end
+        wp = zeros(Float32,nz,nx)
+        wm = zeros(Float32,nz,nx)
+        wp[z1:z2,:] .= 1
+        wm[z1:z2,:] .= 2
+
+        gstd = zeros(Float32,nz,nx)
+        gfwi = zeros(Float32,nz,nx)
+        grtm = zeros(Float32,nz,nx)
+
+        if physics == "ISO"
+            WaveFD.adjointBornAccumulation!(piso, WaveFD.ImagingConditionStandard(), gstd, wp)
+            WaveFD.adjointBornAccumulation!(piso, WaveFD.ImagingConditionWaveFieldSeparationFWI(), gfwi, wp)
+            WaveFD.adjointBornAccumulation!(piso, WaveFD.ImagingConditionWaveFieldSeparationRTM(), grtm, wp)
+        elseif physics == "VTI"
+            w_dict = Dict("pspace" => wp, "mspace" => wm)
+            WaveFD.adjointBornAccumulation!(pvti, WaveFD.Prop2DAcoVTIDenQ_DEO2_FDTD_Model_V(), WaveFD.ImagingConditionStandard(), Dict("v" => gstd), w_dict)
+            WaveFD.adjointBornAccumulation!(pvti, WaveFD.Prop2DAcoVTIDenQ_DEO2_FDTD_Model_V(), WaveFD.ImagingConditionWaveFieldSeparationFWI(), Dict("v" => gfwi), w_dict)
+            WaveFD.adjointBornAccumulation!(pvti, WaveFD.Prop2DAcoVTIDenQ_DEO2_FDTD_Model_V(), WaveFD.ImagingConditionWaveFieldSeparationRTM(), Dict("v" => grtm), w_dict)
+        elseif physics == "TTI"
+            w_dict = Dict("pspace" => wp, "mspace" => wm)
+            WaveFD.adjointBornAccumulation!(ptti, WaveFD.Prop2DAcoTTIDenQ_DEO2_FDTD_Model_V(), WaveFD.ImagingConditionStandard(), Dict("v" => gstd), w_dict)
+            WaveFD.adjointBornAccumulation!(ptti, WaveFD.Prop2DAcoTTIDenQ_DEO2_FDTD_Model_V(), WaveFD.ImagingConditionWaveFieldSeparationFWI(), Dict("v" => gfwi), w_dict)
+            WaveFD.adjointBornAccumulation!(ptti, WaveFD.Prop2DAcoTTIDenQ_DEO2_FDTD_Model_V(), WaveFD.ImagingConditionWaveFieldSeparationRTM(), Dict("v" => grtm), w_dict)
+        end
+
+        @test minimum(gstd) ≥ 0
+        @test maximum(gstd) ≥ 0
+        @test minimum(gfwi) > 0
+        @test maximum(gfwi) > 0
+        @test minimum(grtm) < 0
+        @test maximum(grtm) > 0
+        @test sum(sign.(gfwi)) > sum(sign.(gstd))
+        @test dot(gstd,gfwi) > dot(gstd,grtm)
+    end
+
+    @testset "Imaging Condition 3D tests, $(physics)" for physics in ("ISO", "VTI", "TTI")
+        if physics == "ISO"
+            piso = WaveFD.Prop3DAcoIsoDenQ_DEO2_FDTD(freesurface=false, nz=nz, ny=ny, nx=nx, dz=dz, dy=dy, dx=dx, dt=dt, nthreads=nthreads)
+            WaveFD.B(piso) .= 1
+            WaveFD.V(piso) .= 1
+            WaveFD.POld(piso)[z1:z2,:,:] .= 1
+        elseif physics == "VTI"
+            pvti = WaveFD.Prop3DAcoVTIDenQ_DEO2_FDTD(freesurface=false, nz=nz, ny=ny, nx=nx, dz=dz, dy=dy, dx=dx, dt=dt, nthreads=nthreads)
+            WaveFD.B(pvti) .= 1
+            WaveFD.V(pvti) .= 1
+            WaveFD.POld(pvti)[z1:z2,:,:] .= 1
+            WaveFD.MOld(pvti)[z1:z2,:,:] .= 2
+        elseif physics == "TTI"
+            ptti = WaveFD.Prop3DAcoTTIDenQ_DEO2_FDTD(freesurface=false, nz=nz, ny=ny, nx=nx, dz=dz, dy=dy, dx=dx, dt=dt, nthreads=nthreads)
+            WaveFD.B(ptti) .= 1
+            WaveFD.V(ptti) .= 1
+            WaveFD.POld(ptti)[z1:z2,:,:] .= 1
+            WaveFD.MOld(ptti)[z1:z2,:,:] .= 2
+        end
+
+        wp = zeros(Float32,nz,ny,nx)
+        wm = zeros(Float32,nz,ny,nx)
+        wp[z1:z2,:,:] .= 1
+        wm[z1:z2,:,:] .= 2
+
+        gstd = zeros(Float32,nz,ny,nx)
+        gfwi = zeros(Float32,nz,ny,nx)
+        grtm = zeros(Float32,nz,ny,nx)
+
+        if physics == "ISO"
+            WaveFD.adjointBornAccumulation!(piso, WaveFD.ImagingConditionStandard(), gstd, wp)
+            WaveFD.adjointBornAccumulation!(piso, WaveFD.ImagingConditionWaveFieldSeparationFWI(), gfwi, wp)
+            WaveFD.adjointBornAccumulation!(piso, WaveFD.ImagingConditionWaveFieldSeparationRTM(), grtm, wp)
+        elseif physics == "VTI"
+            w_dict = Dict("pspace" => wp, "mspace" => wm)
+            WaveFD.adjointBornAccumulation!(pvti, WaveFD.Prop3DAcoVTIDenQ_DEO2_FDTD_Model_V(), WaveFD.ImagingConditionStandard(), Dict("v" => gstd), w_dict)
+            WaveFD.adjointBornAccumulation!(pvti, WaveFD.Prop3DAcoVTIDenQ_DEO2_FDTD_Model_V(), WaveFD.ImagingConditionWaveFieldSeparationFWI(), Dict("v" => gfwi), w_dict)
+            WaveFD.adjointBornAccumulation!(pvti, WaveFD.Prop3DAcoVTIDenQ_DEO2_FDTD_Model_V(), WaveFD.ImagingConditionWaveFieldSeparationRTM(), Dict("v" => grtm), w_dict)
+        elseif physics == "TTI"
+            w_dict = Dict("pspace" => wp, "mspace" => wm)
+            WaveFD.adjointBornAccumulation!(ptti, WaveFD.Prop3DAcoTTIDenQ_DEO2_FDTD_Model_V(), WaveFD.ImagingConditionStandard(), Dict("v" => gstd), w_dict)
+            WaveFD.adjointBornAccumulation!(ptti, WaveFD.Prop3DAcoTTIDenQ_DEO2_FDTD_Model_V(), WaveFD.ImagingConditionWaveFieldSeparationFWI(), Dict("v" => gfwi), w_dict)
+            WaveFD.adjointBornAccumulation!(ptti, WaveFD.Prop3DAcoTTIDenQ_DEO2_FDTD_Model_V(), WaveFD.ImagingConditionWaveFieldSeparationRTM(), Dict("v" => grtm), w_dict)
+        end
+
+        @test minimum(gstd) ≥ 0
+        @test maximum(gstd) ≥ 0
+        @test minimum(gfwi) > 0
+        @test maximum(gfwi) > 0
+        @test minimum(grtm) < 0
+        @test maximum(grtm) > 0
+        @test sum(sign.(gfwi)) > sum(sign.(gstd))
+        @test dot(gstd,gfwi) > dot(gstd,grtm)
+    end
+end
+
+nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 for filename in (
         "compressedio.jl",
+        "imgcondition.jl",
         "spacetime.jl",
         "wavelet.jl")
     include(filename)


### PR DESCRIPTION
Placeholder until we know what to do with Yggdrasil, this is currently stomping the libraries set by WaveFD_jll. Currently removes `using WaveFD_jll`.