### PR TITLE
added causal ormsby to wavelet options

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "WaveFD"
 uuid = "44f9e87b-acd6-44e6-b5b0-e1db9a6b2dd4"
-version = "0.6.2"
+version = "0.6.3"
 
 [deps]
 CvxCompress = "3e489a4b-a92a-5e1b-a7bf-ed666eae205e"

--- a/src/WaveFD.jl
+++ b/src/WaveFD.jl
@@ -64,6 +64,7 @@ WaveletMinPhaseRicker,
 WaveletCausalRicker,
 WaveletOrmsby,
 WaveletMinPhaseOrmsby,
+WaveletCausalOrmsby,
 WaveletRicker,
 WaveletSine
 

--- a/test/wavelet.jl
+++ b/test/wavelet.jl
@@ -21,13 +21,27 @@ using FFTW, LinearAlgebra, Test, WaveFD
         @test isapprox(err, 0.0, atol=.01*maximum(W1))
     end
 
-    @testset "Types, wtype=$(wtype)" for wtype in (WaveletSine, WaveletRicker, WaveletMinPhaseRicker, WaveletDerivRicker, WaveletOrmsby, WaveletMinPhaseOrmsby)
+    @testset "Causal ormsby wavelet tests" begin
+        # check amplitude spectrum of Causal Ormsby
+        nt=1024
+        dt=.004
+        f1,f2,f3,f4 = 2.0,4.0,6.0,8.0
+
+        w1 = get(WaveletOrmsby(a=1.0, f1=f1, f2=f2, f3=f3, f4=f4), dt*collect(-div(nt,2):div(nt,2)-1))
+        w2 = get(WaveletCausalOrmsby(a=1.0, f1=f1, f2=f2, f3=f3, f4=f4,tol=0.004), dt*collect(-div(nt,2):div(nt,2)-1))
+        W1 = abs.(rfft(w1))
+        W2 = abs.(rfft(w2))
+        err = norm(abs.(W2) - abs.(W1))/length(W1)
+        @test isapprox(err, 0.0, atol=.01*maximum(W1))
+    end
+
+    @testset "Types, wtype=$(wtype)" for wtype in (WaveletSine, WaveletRicker, WaveletMinPhaseRicker, WaveletDerivRicker, WaveletOrmsby, WaveletMinPhaseOrmsby, WaveletCausalOrmsby)
         @test eltype(get(wtype(), Float64(.004)*collect(0:511))) == Float64
         @test eltype(get(wtype(), Float32(.004)*collect(0:511))) == Float32
     end
 
     @testset "copy methods" begin
-        for W in (WaveletSine, WaveletRicker, WaveletMinPhaseRicker, WaveletDerivRicker, WaveletCausalRicker, WaveletOrmsby, WaveletMinPhaseOrmsby)
+        for W in (WaveletSine, WaveletRicker, WaveletMinPhaseRicker, WaveletDerivRicker, WaveletCausalRicker, WaveletOrmsby, WaveletMinPhaseOrmsby, WaveletCausalOrmsby)
             global w = W()
             global wcopy = copy(w)
             for f in fieldnames(typeof(w))
@@ -38,5 +52,7 @@ using FFTW, LinearAlgebra, Test, WaveFD
         end
     end
 end
+
+
 
 nothing


### PR DESCRIPTION
Added option for causal ormsby wavelet following the causal ricker code. This is required to get the acausal lobes of the ormsby in Devito propagation, due to the delay time not working as intended at this time. 